### PR TITLE
c220 - ignore absent dimm

### DIFF
--- a/cisco/c220/exporter.go
+++ b/cisco/c220/exporter.go
@@ -542,6 +542,8 @@ func (e *Exporter) exportMemoryMetrics(body []byte) error {
 						case nil:
 							state = OK
 						}
+					} else if s["State"].(string) == "Absent" {
+						return nil
 					} else {
 						state = BAD
 					}


### PR DESCRIPTION
Added an if statement to ignore if DIMM is not installed in slot. Example of Redfish API response below for reference.

```
	"Status":	{
		"State":	"Absent"
	}
```