### PR TITLE
update fetching response on power and raid metrics

### DIFF
--- a/cisco/s3260m4/exporter.go
+++ b/cisco/s3260m4/exporter.go
@@ -207,11 +207,20 @@ func NewExporter(ctx context.Context, target, uri, profile string) (*Exporter, e
 		)
 	}
 
+	rcontrollers, err := getRaidEndpoint(fqdn.String()+uri+"/Systems/"+serial+"/Storage", target, retryClient)
+	if err != nil {
+		log.Error("error when getting storage controller endpoints from "+S3260M4, zap.Error(err), zap.Any("trace_id", ctx.Value("traceID")))
+		return nil, err
+	}
+
+	for _, rcontroller := range rcontrollers.Members {
+		tasks = append(tasks,
+			pool.NewTask(common.Fetch(fqdn.String()+rcontroller.URL, DRIVE, target, profile, retryClient)))
+	}
+
 	tasks = append(tasks,
 		pool.NewTask(common.Fetch(fqdn.String()+mgr+"/Processors/CPU1", PROCESSOR, target, profile, retryClient)),
-		pool.NewTask(common.Fetch(fqdn.String()+mgr+"/Processors/CPU2", PROCESSOR, target, profile, retryClient)),
-		pool.NewTask(common.Fetch(fqdn.String()+uri+"/Systems/"+serial+"/Storage/SBMezz1", DRIVE, target, profile, retryClient)),
-		pool.NewTask(common.Fetch(fqdn.String()+uri+"/Systems/"+serial+"/Storage/IOEMezz1", DRIVE, target, profile, retryClient)))
+		pool.NewTask(common.Fetch(fqdn.String()+mgr+"/Processors/CPU2", PROCESSOR, target, profile, retryClient)))
 
 	for _, dimm := range dimms.Members {
 		tasks = append(tasks,
@@ -742,4 +751,46 @@ func getDIMMEndpoints(url, host string, client *retryablehttp.Client) (Collectio
 	}
 
 	return dimms, nil
+}
+
+func getRaidEndpoint(url, host string, client *retryablehttp.Client) (Collection, error) {
+	var rcontrollers Collection
+	var resp *http.Response
+	var err error
+	retryCount := 0
+	req := common.BuildRequest(url, host)
+
+	resp, err = common.DoRequest(client, req)
+	if err != nil {
+		return rcontrollers, err
+	}
+	defer resp.Body.Close()
+	if !(resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices) {
+		if resp.StatusCode == http.StatusNotFound {
+			for retryCount < 3 && resp.StatusCode == http.StatusNotFound {
+				time.Sleep(client.RetryWaitMin)
+				resp, err = common.DoRequest(client, req)
+				retryCount = retryCount + 1
+			}
+			if err != nil {
+				return rcontrollers, err
+			} else if !(resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices) {
+				return rcontrollers, fmt.Errorf("HTTP status %d", resp.StatusCode)
+			}
+		} else {
+			return rcontrollers, fmt.Errorf("HTTP status %d", resp.StatusCode)
+		}
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return rcontrollers, fmt.Errorf("Error reading Response Body - " + err.Error())
+	}
+
+	err = json.Unmarshal(body, &rcontrollers)
+	if err != nil {
+		return rcontrollers, fmt.Errorf("Error Unmarshalling S3260M5 Chassis struct - " + err.Error())
+	}
+
+	return rcontrollers, nil
 }

--- a/hpe/dl360/exporter.go
+++ b/hpe/dl360/exporter.go
@@ -484,6 +484,8 @@ func (e *Exporter) exportPowerMetrics(body []byte) error {
 		if ps.Status.State == "Enabled" {
 			if ps.MemberID != "" {
 				(*dlPower)["supplyOutput"].WithLabelValues(ps.MemberID, ps.SparePartNumber).Set(float64(ps.LastPowerOutputWatts))
+			} else if strconv.Itoa(ps.Oem.Hpe.BayNumber) != "" {
+				(*dlPower)["supplyOutput"].WithLabelValues(strconv.Itoa(ps.Oem.Hpe.BayNumber), ps.SparePartNumber).Set(float64(ps.LastPowerOutputWatts))
 			} else {
 				(*dlPower)["supplyOutput"].WithLabelValues(strconv.Itoa(ps.Oem.Hp.BayNumber), ps.SparePartNumber).Set(float64(ps.LastPowerOutputWatts))
 			}
@@ -494,6 +496,8 @@ func (e *Exporter) exportPowerMetrics(body []byte) error {
 			}
 			if ps.MemberID != "" {
 				(*dlPower)["supplyStatus"].WithLabelValues(ps.MemberID, ps.SparePartNumber).Set(state)
+			} else if strconv.Itoa(ps.Oem.Hpe.BayNumber) != "" {
+				(*dlPower)["supplyStatus"].WithLabelValues(strconv.Itoa(ps.Oem.Hpe.BayNumber), ps.SparePartNumber).Set(state)
 			} else {
 				(*dlPower)["supplyStatus"].WithLabelValues(strconv.Itoa(ps.Oem.Hp.BayNumber), ps.SparePartNumber).Set(state)
 			}


### PR DESCRIPTION
This PR will address #39 .

Cisco S3260 M4/M5:
Updated to gather storage controller endpoints and then loop for data collection instead of using static path.

HP DL360:
Updated Power Supply response collected to include "Hpe" key from response.