### PR TITLE
new metrics to dl360 and xl420

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ log is based on the [Keep a CHANGELOG](http://keepachangelog.com/) project.
 - Removed references to internal URLs/FQDNs to opensource the project
 - Cisco S3260M5 module to support FW Ver 4.2(xx) [#18](https://github.com/Comcast/fishymetrics/issues/18)
 - HP DL360 module to support responses from iLO4 [#34](https://github.com/Comcast/fishymetrics/issues/34)
+- HP DL360 & XL420 to include processor, iloselftest and smart storage battery metrics [#43](https://github.com/Comcast/fishymetrics/issues/43)
 
 ## [0.7.1]
 

--- a/hpe/dl360/chassis.go
+++ b/hpe/dl360/chassis.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dl360
+
+// Collection returns an array of the endpoints from the chassis pertaining to a resource type
+type Collection struct {
+	Members []struct {
+		URL string `json:"@odata.id"`
+	} `json:"Members"`
+	MembersCount int `json:"Members@odata.count"`
+}
+
+// /redfish/v1/Systems/1/ or /redfish/v1/Managers/1/
+type SystemMetrics struct {
+	Oem OemSys `json:"Oem"`
+}
+
+type OemSys struct {
+	Hpe HpeSys `json:"Hpe,omitempty"`
+	Hp  HpeSys `json:"Hp,omitempty"`
+}
+
+type HpeSys struct {
+	Battery     []StorageBattery `json:"Battery"`
+	IloSelfTest []IloSelfTest    `json:"iLOSelfTestResults"`
+}
+
+type StorageBattery struct {
+	Condition    string `json:"Condition"`
+	Index        int    `json:"Index"`
+	Model        string `json:"Model"`
+	Present      string `json:"Present"`
+	Name         string `json:"ProductName"`
+	SerialNumber string `json:"SerialNumber"`
+}
+
+type IloSelfTest struct {
+	Name   string `json:"SelfTestName"`
+	Status string `json:"Status"`
+	Notes  string `json:"Notes"`
+}

--- a/hpe/dl360/metrics.go
+++ b/hpe/dl360/metrics.go
@@ -53,6 +53,18 @@ func NewDeviceMetrics() *map[string]*metrics {
 			"supplyTotalCapacity": newServerMetric("dl360_power_supply_total_capacity", "Total output capacity of all the power supplies", nil, []string{"memberId"}),
 		}
 
+		ProcessorMetrics = &metrics{
+			"processorStatus": newServerMetric("dl360_cpu_status", "Current cpu status 1 = OK, 0 = BAD", nil, []string{"id", "socket", "model", "totalCores"}),
+		}
+
+		IloSelfTestMetrics = &metrics{
+			"iloSelfTestStatus": newServerMetric("dl360_ilo_selftest_status", "Current ilo selftest status 1 = OK, 0 = BAD", nil, []string{"name"}),
+		}
+
+		StorageBatteryMetrics = &metrics{
+			"storageBatteryStatus": newServerMetric("dl360_storage_battery_status", "Current storage battery status 1 = OK, 0 = BAD", nil, []string{"id", "name", "model", "serialnumber"}),
+		}
+
 		// Splitting out the three different types of drives to gather metrics on each (NVMe, Disk Drive, and Logical Drive)
 		// NVMe Drive Metrics
 		NVMeDriveMetrics = &metrics{
@@ -77,9 +89,12 @@ func NewDeviceMetrics() *map[string]*metrics {
 			"up":                  UpMetric,
 			"thermalMetrics":      ThermalMetrics,
 			"powerMetrics":        PowerMetrics,
+			"processorMetrics":    ProcessorMetrics,
 			"nvmeMetrics":         NVMeDriveMetrics,
 			"diskDriveMetrics":    DiskDriveMetrics,
 			"logicalDriveMetrics": LogicalDriveMetrics,
+			"storBatteryMetrics":  StorageBatteryMetrics,
+			"iloSelfTestMetrics":  IloSelfTestMetrics,
 			"memoryMetrics":       MemoryMetrics,
 		}
 	)

--- a/hpe/dl360/processor.go
+++ b/hpe/dl360/processor.go
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dl360
+
+// /redfish/v1/Systems/1/Processors/X/
+type ProcessorMetrics struct {
+	Id           string `json:"Id"`
+	Model        string `json:"Model"`
+	Socket       string `json:"Socket"`
+	Status       Status `json:"Status"`
+	TotalCores   int    `json:"TotalCores"`
+	TotalThreads int    `json:"TotalThreads"`
+}

--- a/hpe/xl420/chassis.go
+++ b/hpe/xl420/chassis.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xl420
+
+// Collection returns an array of the endpoints from the chassis pertaining to a resource type
+type Collection struct {
+	Members []struct {
+		URL string `json:"@odata.id"`
+	} `json:"Members"`
+	MembersCount int `json:"Members@odata.count"`
+}
+
+// /redfish/v1/Systems/1/ or /redfish/v1/Managers/1/
+type SystemMetrics struct {
+	Oem OemSys `json:"Oem"`
+}
+
+type OemSys struct {
+	Hpe HpeSys `json:"Hpe,omitempty"`
+	Hp  HpeSys `json:"Hp,omitempty"`
+}
+
+type HpeSys struct {
+	Battery     []StorageBattery `json:"Battery"`
+	IloSelfTest []IloSelfTest    `json:"iLOSelfTestResults"`
+}
+
+type StorageBattery struct {
+	Condition    string `json:"Condition"`
+	Index        int    `json:"Index"`
+	Model        string `json:"Model"`
+	Present      string `json:"Present"`
+	Name         string `json:"ProductName"`
+	SerialNumber string `json:"SerialNumber"`
+}
+
+type IloSelfTest struct {
+	Name   string `json:"SelfTestName"`
+	Status string `json:"Status"`
+	Notes  string `json:"Notes"`
+}

--- a/hpe/xl420/exporter.go
+++ b/hpe/xl420/exporter.go
@@ -55,6 +55,12 @@ const (
 	LOGICALDRIVE = "LogicalDriveMetrics"
 	// MEMORY represents the memory metric endpoints
 	MEMORY = "MemoryMetrics"
+	// PROCESSOR represents the processor metric endpoints
+	PROCESSOR = "ProcessorMetrics"
+	// STORAGEBATTERY represents the processor metric endpoints
+	STORAGEBATTERY = "storBatteryMetrics"
+	// ILOSELFTEST represents the processor metric endpoints
+	ILOSELFTEST = "iloSelfTestMetrics"
 	// OK is a string representation of the float 1.0 for device status
 	OK = 1.0
 	// BAD is a string representation of the float 0.0 for device status
@@ -264,7 +270,20 @@ func NewExporter(ctx context.Context, target, uri, profile string) (*Exporter, e
 	tasks = append(tasks,
 		pool.NewTask(common.Fetch(fqdn.String()+uri+"/Chassis/1/Thermal/", THERMAL, target, profile, retryClient)),
 		pool.NewTask(common.Fetch(fqdn.String()+uri+"/Chassis/1/Power/", POWER, target, profile, retryClient)),
-		pool.NewTask(common.Fetch(fqdn.String()+uri+"/Systems/1/", MEMORY, target, profile, retryClient)))
+		pool.NewTask(common.Fetch(fqdn.String()+uri+"/Systems/1/", MEMORY, target, profile, retryClient)),
+		pool.NewTask(common.Fetch(fqdn.String()+uri+"/Systems/1/", STORAGEBATTERY, target, profile, retryClient)),
+		pool.NewTask(common.Fetch(fqdn.String()+uri+"/Managers/1/", ILOSELFTEST, target, profile, retryClient)))
+
+	processors, err := getProcessorEndpoints(fqdn.String()+uri+"/Systems/1/Processors/", target, retryClient)
+	if err != nil {
+		log.Error("error when getting Processors endpoints from "+XL420, zap.Error(err), zap.Any("trace_id", ctx.Value("traceID")))
+		return nil, err
+	}
+
+	for _, processor := range processors.Members {
+		tasks = append(tasks,
+			pool.NewTask(common.Fetch(fqdn.String()+processor.URL, PROCESSOR, target, profile, retryClient)))
+	}
 
 	exp.pool = pool.NewPool(tasks, 1)
 
@@ -361,6 +380,12 @@ func (e *Exporter) scrape() {
 			err = e.exportLogicalDriveMetrics(task.Body)
 		case MEMORY:
 			err = e.exportMemoryMetrics(task.Body)
+		case PROCESSOR:
+			err = e.exportProcessorMetrics(task.Body)
+		case STORAGEBATTERY:
+			err = e.exportStorageBattery(task.Body)
+		case ILOSELFTEST:
+			err = e.exportIloSelfTest(task.Body)
 		}
 
 		if err != nil {
@@ -528,7 +553,7 @@ func (e *Exporter) exportPhysicalDriveMetrics(body []byte) error {
 	return nil
 }
 
-// exportNVMeDriveMetrics collects the DL360 NVME drive metrics in json format and sets the prometheus gauges
+// exportNVMeDriveMetrics collects the XL420 NVME drive metrics in json format and sets the prometheus gauges
 func (e *Exporter) exportNVMeDriveMetrics(body []byte) error {
 	var state float64
 	var dlnvme NVMeDriveMetrics
@@ -553,6 +578,44 @@ func (e *Exporter) exportNVMeDriveMetrics(body []byte) error {
 	return nil
 }
 
+// exportStorageBattery collects the XL420's smart storge battery metrics in json format and sets the prometheus guage
+func (e *Exporter) exportStorageBattery(body []byte) error {
+
+	var state float64
+	var sysm SystemMetrics
+	var storBattery = (*e.deviceMetrics)["storBatteryMetrics"]
+	err := json.Unmarshal(body, &sysm)
+	if err != nil {
+		return fmt.Errorf("Error Unmarshalling XL420 Storage Battery Metrics - " + err.Error())
+	}
+
+	if fmt.Sprint(sysm.Oem.Hp.Battery) != "null" && len(sysm.Oem.Hp.Battery) > 0 {
+		for _, ssbat := range sysm.Oem.Hp.Battery {
+			if ssbat.Present == "Yes" {
+				if ssbat.Condition == "Ok" {
+					state = OK
+				} else {
+					state = BAD
+				}
+				(*storBattery)["storageBatteryStatus"].WithLabelValues(strconv.Itoa(ssbat.Index), ssbat.Name, ssbat.Model, ssbat.SerialNumber).Set(state)
+			}
+		}
+	} else if fmt.Sprint(sysm.Oem.Hpe.Battery) != "null" && len(sysm.Oem.Hpe.Battery) > 0 {
+		for _, ssbat := range sysm.Oem.Hpe.Battery {
+			if ssbat.Present == "Yes" {
+				if ssbat.Condition == "Ok" {
+					state = OK
+				} else {
+					state = BAD
+				}
+				(*storBattery)["storageBatteryStatus"].WithLabelValues(strconv.Itoa(ssbat.Index), ssbat.Name, ssbat.Model, ssbat.SerialNumber).Set(state)
+			}
+		}
+	}
+
+	return nil
+}
+
 // exportMemoryMetrics collects the XL420 drive metrics in json format and sets the prometheus gauges
 func (e *Exporter) exportMemoryMetrics(body []byte) error {
 
@@ -571,6 +634,65 @@ func (e *Exporter) exportMemoryMetrics(body []byte) error {
 	}
 
 	(*dlMemory)["memoryStatus"].WithLabelValues(strconv.Itoa(dlm.MemorySummary.TotalSystemMemoryGiB)).Set(state)
+
+	return nil
+}
+
+// exportProcessorMetrics collects the XL420 processor metrics in json format and sets the prometheus gauges
+func (e *Exporter) exportProcessorMetrics(body []byte) error {
+
+	var state float64
+	var pm ProcessorMetrics
+	var proc = (*e.deviceMetrics)["processorMetrics"]
+	err := json.Unmarshal(body, &pm)
+	if err != nil {
+		return fmt.Errorf("Error Unmarshalling XL420 ProcessorMetrics - " + err.Error())
+	}
+
+	if pm.Status.Health == "OK" {
+		state = OK
+	} else {
+		state = BAD
+	}
+	(*proc)["processorStatus"].WithLabelValues(pm.Id, pm.Socket, pm.Model, strconv.Itoa(pm.TotalCores)).Set(state)
+
+	return nil
+}
+
+// exportIloSelfTest collects the XL420's iLO Self Test Results metrics in json format and sets the prometheus guage
+func (e *Exporter) exportIloSelfTest(body []byte) error {
+
+	var state float64
+	var sysm SystemMetrics
+	var iloSelfTst = (*e.deviceMetrics)["iloSelfTestMetrics"]
+	err := json.Unmarshal(body, &sysm)
+	if err != nil {
+		return fmt.Errorf("Error Unmarshalling XL420 iLO Self Test Metrics - " + err.Error())
+	}
+
+	if fmt.Sprint(sysm.Oem.Hp.IloSelfTest) != "null" && len(sysm.Oem.Hp.IloSelfTest) > 0 {
+		for _, ilost := range sysm.Oem.Hp.IloSelfTest {
+			if ilost.Status != "Informational" {
+				if ilost.Status == "OK" {
+					state = OK
+				} else {
+					state = BAD
+				}
+				(*iloSelfTst)["iloSelfTestStatus"].WithLabelValues(ilost.Name).Set(state)
+			}
+		}
+	} else if fmt.Sprint(sysm.Oem.Hpe.IloSelfTest) != "null" && len(sysm.Oem.Hpe.IloSelfTest) > 0 {
+		for _, ilost := range sysm.Oem.Hpe.IloSelfTest {
+			if ilost.Status != "Informational" {
+				if ilost.Status == "OK" {
+					state = OK
+				} else {
+					state = BAD
+				}
+				(*iloSelfTst)["iloSelfTestStatus"].WithLabelValues(ilost.Name).Set(state)
+			}
+		}
+	}
 
 	return nil
 }
@@ -617,4 +739,48 @@ func getDriveEndpoint(url, host string, client *retryablehttp.Client) (GenericDr
 	}
 
 	return drive, nil
+}
+
+func getProcessorEndpoints(url, host string, client *retryablehttp.Client) (Collection, error) {
+	var processors Collection
+	var resp *http.Response
+	var err error
+	retryCount := 0
+	req := common.BuildRequest(url, host)
+
+	resp, err = common.DoRequest(client, req)
+	if err != nil {
+		return processors, err
+	}
+	defer resp.Body.Close()
+	if !(resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices) {
+		if resp.StatusCode == http.StatusNotFound {
+			for retryCount < 3 && resp.StatusCode == http.StatusNotFound {
+				time.Sleep(client.RetryWaitMin)
+				resp, err = common.DoRequest(client, req)
+				retryCount = retryCount + 1
+			}
+			if err != nil {
+				return processors, err
+			} else if !(resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices) {
+				return processors, fmt.Errorf("HTTP status %d", resp.StatusCode)
+			}
+		} else if resp.StatusCode == http.StatusUnauthorized {
+			return processors, common.ErrInvalidCredential
+		} else {
+			return processors, fmt.Errorf("HTTP status %d", resp.StatusCode)
+		}
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return processors, fmt.Errorf("Error reading Response Body - " + err.Error())
+	}
+
+	err = json.Unmarshal(body, &processors)
+	if err != nil {
+		return processors, fmt.Errorf("Error Unmarshalling XL420 Processors Collection struct - " + err.Error())
+	}
+
+	return processors, nil
 }

--- a/hpe/xl420/metrics.go
+++ b/hpe/xl420/metrics.go
@@ -53,6 +53,18 @@ func NewDeviceMetrics() *map[string]*metrics {
 			"supplyTotalCapacity": newServerMetric("xl420_power_supply_total_capacity", "Total output capacity of all the power supplies", nil, []string{"memberId"}),
 		}
 
+		ProcessorMetrics = &metrics{
+			"processorStatus": newServerMetric("xl420_cpu_status", "Current cpu status 1 = OK, 0 = BAD", nil, []string{"id", "socket", "model", "totalCores"}),
+		}
+
+		IloSelfTestMetrics = &metrics{
+			"iloSelfTestStatus": newServerMetric("xl420_ilo_selftest_status", "Current ilo selftest status 1 = OK, 0 = BAD", nil, []string{"name"}),
+		}
+
+		StorageBatteryMetrics = &metrics{
+			"storageBatteryStatus": newServerMetric("xl420_storage_battery_status", "Current storage battery status 1 = OK, 0 = BAD", nil, []string{"id", "name", "model", "serialnumber"}),
+		}
+
 		// Splitting out the three different types of drives to gather metrics on each (NVMe, Disk Drive, and Logical Drive)
 		// NVMe Drive Metrics
 		NVMeDriveMetrics = &metrics{
@@ -77,9 +89,12 @@ func NewDeviceMetrics() *map[string]*metrics {
 			"up":                  UpMetric,
 			"thermalMetrics":      ThermalMetrics,
 			"powerMetrics":        PowerMetrics,
+			"processorMetrics":    ProcessorMetrics,
 			"nvmeMetrics":         NVMeDriveMetrics,
 			"diskDriveMetrics":    DiskDriveMetrics,
 			"logicalDriveMetrics": LogicalDriveMetrics,
+			"storBatteryMetrics":  StorageBatteryMetrics,
+			"iloSelfTestMetrics":  IloSelfTestMetrics,
 			"memoryMetrics":       MemoryMetrics,
 		}
 	)

--- a/hpe/xl420/processor.go
+++ b/hpe/xl420/processor.go
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xl420
+
+// /redfish/v1/Systems/1/Processors/X/
+type ProcessorMetrics struct {
+	Id           string `json:"Id"`
+	Model        string `json:"Model"`
+	Socket       string `json:"Socket"`
+	Status       Status `json:"Status"`
+	TotalCores   int    `json:"TotalCores"`
+	TotalThreads int    `json:"TotalThreads"`
+}


### PR DESCRIPTION
This PR addresses #43. It includes changes to pull export metrics for following components in both HP DL360 and XL420 server models.

Redacted few information in below output.
```
# HELP xl420_cpu_status Current cpu status 1 = OK, 0 = BAD
# TYPE xl420_cpu_status gauge
xl420_cpu_status{id="1",model="xxxxxxxxxxxxxxx",socket="Proc 1",totalCores="12"} 1
xl420_cpu_status{id="2",model="xxxxxxxxxxxxxxx",socket="Proc 2",totalCores="12"} 1
# HELP xl420_ilo_selftest_status Current ilo selftest status 1 = OK, 0 = BAD
# TYPE xl420_ilo_selftest_status gauge
xl420_ilo_selftest_status{name="EEPROM"} 1
xl420_ilo_selftest_status{name="EmbeddedFlash/SDCard"} 1
xl420_ilo_selftest_status{name="HostRom"} 1
xl420_ilo_selftest_status{name="NVRAMData"} 1
xl420_ilo_selftest_status{name="NVRAMSpace"} 1
xl420_ilo_selftest_status{name="SupportedHost"} 1
# HELP xl420_storage_battery_status Current storage battery status 1 = OK, 0 = BAD
# TYPE xl420_storage_battery_status gauge
xl420_storage_battery_status{id="1",model="xxxxxxxxx",name="HPE Smart Storage Battery ",serialnumber="xxxxxxxxx"} 1


# HELP dl360_cpu_status Current cpu status 1 = OK, 0 = BAD
# TYPE dl360_cpu_status gauge
dl360_cpu_status{id="1",model="xxxxxxxxxxxxxxx",socket="Proc 1",totalCores="6"} 1
dl360_cpu_status{id="2",model="xxxxxxxxxxxxxxx",socket="Proc 2",totalCores="6"} 1
# HELP dl360_ilo_selftest_status Current ilo selftest status 1 = OK, 0 = BAD
# TYPE dl360_ilo_selftest_status gauge
dl360_ilo_selftest_status{name="EEPROM"} 1
dl360_ilo_selftest_status{name="EmbeddedFlash/SDCard"} 1
dl360_ilo_selftest_status{name="HostRom"} 1
dl360_ilo_selftest_status{name="NVRAMData"} 1
dl360_ilo_selftest_status{name="SupportedHost"} 1
# HELP dl360_storage_battery_status Current storage battery status 1 = OK, 0 = BAD
# TYPE dl360_storage_battery_status gauge
dl360_storage_battery_status{id="1",model="xxxxxxxxx",name="HPE Smart Storage Battery ",serialnumber="xxxxxxxxx"} 1
```