### PR TITLE
Fix psu status metric and large fw scrape time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ log is based on the [Keep a CHANGELOG](http://keepachangelog.com/) project.
 - Chassis ComputerSystems field is handled improperly [#68](https://github.com/Comcast/fishymetrics/issues/68)
 - Power and Thermal metrics collection for Dell R7xxXD server models [#77](https://github.com/Comcast/fishymetrics/issues/77)
 - Firmware metrics and request headers update for Dell iDRAC9 with FW ver.3.xx and 4.xx [#77](https://github.com/Comcast/fishymetrics/issues/77)
+- Power supply status duplicate bay number metrics [#85] (https://github.com/Comcast/fishymetrics/issues/85)
 
 ## Updated
 
@@ -44,6 +45,7 @@ log is based on the [Keep a CHANGELOG](http://keepachangelog.com/) project.
 - get chassis serial number from JSON response instead of url path [#50](https://github.com/Comcast/fishymetrics/issues/50)
 - HP DL380 module to include CPU metrics and all HP models to include bayNumber in PSU metrics [#57](https://github.com/Comcast/fishymetrics/issues/57)
 - use standard library for http routing instead of gorilla mux package [#47](https://github.com/Comcast/fishymetrics/issues/47)
+- Avoid collecting firmware metrics if count of endpoints are 75 or greater [#77] (https://github.com/Comcast/fishymetrics/issues/77)
 
 ## [0.7.1]
 

--- a/common/credentials.go
+++ b/common/credentials.go
@@ -70,7 +70,7 @@ func (cp *CredentialProfilesFlag) Set(value string) error {
 		// if json was passed in we will attempt to unmarshal differently
 		err := json.Unmarshal([]byte(value), cp)
 		if err != nil {
-			panic(fmt.Errorf("Error parsing argument flag \"--credentials.profiles\" - %s", err.Error()))
+			panic(fmt.Errorf("error parsing argument flag \"--credentials.profiles\" - %s", err.Error()))
 		}
 	}
 	ChassisCreds.populateProfiles(cp)

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -426,13 +426,16 @@ func NewExporter(ctx context.Context, target, uri, profile, model string, exclud
 	}
 
 	// Firmware Inventory
-	for _, fwEp := range firmwareInventoryEndpoints.Members {
-		// this list can potentially be large and cause scrapes to take a long time
-		// see the '--collector.firmware.modules-exclude' config in the README for more information
-		if reg, ok := excludes["firmware"]; ok {
-			if !reg.(*regexp.Regexp).MatchString(fwEp.URL) {
-				tasks = append(tasks,
-					pool.NewTask(common.Fetch(exp.url+fwEp.URL, target, profile, retryClient), exp.url+fwEp.URL, handle(&exp, FIRMWAREINVENTORY)))
+	// To avoid scraping a large number of firmware endpoints, we will only scrape if there are less than 75 members
+	if len(firmwareInventoryEndpoints.Members) < 75 {
+		for _, fwEp := range firmwareInventoryEndpoints.Members {
+			// this list can potentially be large and cause scrapes to take a long time
+			// see the '--collector.firmware.modules-exclude' config in the README for more information
+			if reg, ok := excludes["firmware"]; ok {
+				if !reg.(*regexp.Regexp).MatchString(fwEp.URL) {
+					tasks = append(tasks,
+						pool.NewTask(common.Fetch(exp.url+fwEp.URL, target, profile, retryClient), exp.url+fwEp.URL, handle(&exp, FIRMWAREINVENTORY)))
+				}
 			}
 		}
 	}


### PR DESCRIPTION
https://github.com/Comcast/fishymetrics/commit/a01680e23f4dcbda567dcc2d91c10612a32fb40b

- Capture PSU bay number at start to avoid duplicate entry.
- Ignore PSU status if not installed or absent.


https://github.com/Comcast/fishymetrics/commit/ce2c30f5c9eefbaec34790d0c7381d0238de01b0

- To avoid higher scrape time, limit firmware metric collection if the count of firmware endpoints are less than 75.

