### PR TITLE
Added support for Supermicro models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ log is based on the [Keep a CHANGELOG](http://keepachangelog.com/) project.
 - Ignore CPU metrics if Processor is Absent [#79](https://github.com/Comcast/fishymetrics/issues/79)
 - Added support for metrics collection from Dell servers [#77](https://github.com/Comcast/fishymetrics/issues/77)
 - Added support for firmware metrics collection from all supported servers and iLO versions from a single universal exporter [#83](https://github.com/Comcast/fishymetrics/issues/83)
+- Added support for Supermicro models metrics collection [#87](https://github.com/Comcast/fishymetrics/issues/87)
 
 ## Fixed
 

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -396,9 +396,9 @@ func NewExporter(ctx context.Context, target, uri, profile, model string, exclud
 				log.Error("no update service/system firmware URI to collect firmware metrics",
 					zap.Any("trace_id", ctx.Value("traceID")))
 			}
-		} else {
-			log.Error("error when getting firmware endpoints", zap.Error(err), zap.Any("trace_id", ctx.Value("traceID")))
-		}
+		} 
+	} else {
+		log.Error("error when getting firmware endpoints", zap.Error(err), zap.Any("trace_id", ctx.Value("traceID")))
 	}
 
 	// Firmware Inventory

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -315,11 +315,9 @@ func NewExporter(ctx context.Context, target, uri, profile, model string, exclud
 				handle(&exp, MEMORY_SUMMARY, STORAGEBATTERY)))
 
 		// DIMM endpoints array
-		if sysResp.Memory.URL == "" && len(sysEndpoints.systems) > 0 {
-			sysResp.Memory.URL = sysEndpoints.systems[0] + "Memory/"
-		}
-		dimms, err = getDIMMEndpoints(exp.url+sysResp.Memory.URL, target, retryClient)
-		if err != nil {
+		if sysResp.Memory.URL != "" {
+			dimms, err = getDIMMEndpoints(exp.url+sysResp.Memory.URL, target, retryClient)
+			if err != nil {
 			log.Error("error when getting DIMM endpoints",
 				zap.Error(err),
 				zap.Any("trace_id", ctx.Value("traceID")))

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -349,10 +349,13 @@ func NewExporter(ctx context.Context, target, uri, profile, model string, exclud
 	}
 
 	if len(sysEndpoints.storageController) == 0 && ss == "" {
-		driveEndpointsResp, err = getAllDriveEndpoints(ctx, exp.url, exp.url+sysEndpoints.systems[0]+"Storage/", target, retryClient)
-		if err != nil {
-			log.Error("error when getting drive endpoints", zap.Error(err), zap.Any("trace_id", ctx.Value("traceID")))
-			return nil, err
+		if sysResp.Storage.URL != "" {
+			url := appendSlash(sysResp.Storage.URL)
+			driveEndpointsResp, err = getAllDriveEndpoints(ctx, exp.url, exp.url+url, target, retryClient)
+			if err != nil {
+				log.Error("error when getting drive endpoints", zap.Error(err), zap.Any("trace_id", ctx.Value("traceID")))
+				return nil, err
+			}
 		}
 	}
 
@@ -364,31 +367,40 @@ func NewExporter(ctx context.Context, target, uri, profile, model string, exclud
 	//Firmware Inventory - Try the iLo 4 firmware inventory endpoints using sysEndpoints.systems URL
 	// call /redfish/v1/Systems/XXXX/FirmwareInventory/
 	var systemFML = GetFirmwareInventoryURL(sysResp)
+	var firmwareInventoryEndpoints []string
 	if systemFML != "" {
-		tasks = append(tasks,
-			pool.NewTask(common.Fetch(exp.url+systemFML, target, profile, retryClient),
-				exp.url+systemFML, handle(&exp, FIRMWAREINVENTORY)))
+		tasks = append(tasks, pool.NewTask(common.Fetch(exp.url+systemFML, target, profile, retryClient), exp.url+systemFML, handle(&exp, FIRMWAREINVENTORY)))
 	} else {
 		// Check for /redfish/v1/Managers/XXXX/UpdateService/ for firmware inventory URL
-		updateServiceEndpoints, err := getSystemsMetadata(exp.url+uri+"/UpdateService/", target, retryClient)
-		if updateServiceEndpoints.FirmwareInventory.LinksURLSlice[0] != "" && err == nil {
-			firmwareInventoryEndpoints, err := getFirmwareEndpoints(
-				exp.url+updateServiceEndpoints.FirmwareInventory.LinksURLSlice[0], target, retryClient)
+		rootComponents, err := getSystemsMetadata(exp.url+uri, target, retryClient)
+		if err != nil {
+			log.Error("error when getting root components metadata", zap.Error(err), zap.Any("trace_id", ctx.Value("traceID")))
+			return nil, err
+		}
+		if rootComponents.UpdateService.URL != "" {
+			updateServiceEndpoints, err := getSystemsMetadata(exp.url+rootComponents.UpdateService.URL, target, retryClient)
 			if err != nil {
-				log.Error("error when getting firmware inventory endpoints", zap.Error(err),
-					zap.Any("trace_id", ctx.Value("traceID")))
+				log.Error("error when getting update service metadata", zap.Error(err), zap.Any("trace_id", ctx.Value("traceID")))
 				return nil, err
 			}
-			// To avoid scraping a large number of firmware endpoints, we will only scrape if there are less than 75 members
-			if len(firmwareInventoryEndpoints.Members) < 75 {
-				for _, fwEp := range firmwareInventoryEndpoints.Members {
+
+			if len(updateServiceEndpoints.FirmwareInventory.LinksURLSlice) == 1 {
+				firmwareInventoryEndpoints, err = getMemberUrls(exp.url+updateServiceEndpoints.FirmwareInventory.LinksURLSlice[0], target, retryClient)
+				if err != nil {
+					log.Error("error when getting firmware inventory endpoints", zap.Error(err), zap.Any("trace_id", ctx.Value("traceID")))
+					return nil, err
+				}
+			} else if len(updateServiceEndpoints.FirmwareInventory.LinksURLSlice) > 1 {
+				firmwareInventoryEndpoints = updateServiceEndpoints.FirmwareInventory.LinksURLSlice
+			}
+
+			if len(firmwareInventoryEndpoints) < 75 {
+				for _, fwEp := range firmwareInventoryEndpoints {
 					// this list can potentially be large and cause scrapes to take a long time
 					// see the '--collector.firmware.modules-exclude' config in the README for more information
 					if reg, ok := excludes["firmware"]; ok {
-						if !reg.(*regexp.Regexp).MatchString(fwEp.URL) {
-							tasks = append(tasks,
-								pool.NewTask(common.Fetch(exp.url+fwEp.URL, target, profile, retryClient),
-									exp.url+fwEp.URL, handle(&exp, FIRMWAREINVENTORY)))
+						if !reg.(*regexp.Regexp).MatchString(fwEp) {
+							tasks = append(tasks, pool.NewTask(common.Fetch(exp.url+fwEp, target, profile, retryClient), exp.url+fwEp, handle(&exp, FIRMWAREINVENTORY)))
 						}
 					}
 				}

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -315,9 +315,11 @@ func NewExporter(ctx context.Context, target, uri, profile, model string, exclud
 				handle(&exp, MEMORY_SUMMARY, STORAGEBATTERY)))
 
 		// DIMM endpoints array
-		if sysResp.Memory.URL != "" {
-			dimms, err = getDIMMEndpoints(exp.url+sysResp.Memory.URL, target, retryClient)
-			if err != nil {
+		if sysResp.Memory.URL == "" {
+			sysResp.Memory.URL = sysEndpoints.systems[0] + "Memory/"
+		}
+		dimms, err = getDIMMEndpoints(exp.url+sysResp.Memory.URL, target, retryClient)
+		if err != nil {
 			log.Error("error when getting DIMM endpoints",
 				zap.Error(err),
 				zap.Any("trace_id", ctx.Value("traceID")))
@@ -394,9 +396,7 @@ func NewExporter(ctx context.Context, target, uri, profile, model string, exclud
 				log.Error("no update service/system firmware URI to collect firmware metrics",
 					zap.Any("trace_id", ctx.Value("traceID")))
 			}
-		} 
-	} else {
-		log.Error("error when getting firmware endpoints", zap.Error(err), zap.Any("trace_id", ctx.Value("traceID")))
+		}
 	}
 
 	// Firmware Inventory

--- a/exporter/handlers.go
+++ b/exporter/handlers.go
@@ -161,9 +161,13 @@ func (e *Exporter) exportPowerMetrics(body []byte) error {
 				watts = ps.LastPowerOutputWatts.(float64)
 			case string:
 				watts, _ = strconv.ParseFloat(ps.LastPowerOutputWatts.(string), 32)
+			default:
+				watts = 9999
 			}
 
-			(*pow)["supplyOutput"].WithLabelValues(ps.Name, e.ChassisSerialNumber, e.Model, strings.TrimRight(ps.Manufacturer, " "), ps.SerialNumber, ps.FirmwareVersion, ps.PowerSupplyType, strconv.Itoa(bay), ps.Model).Set(watts)
+			if watts != 9999 {
+				(*pow)["supplyOutput"].WithLabelValues(ps.Name, e.ChassisSerialNumber, e.Model, strings.TrimRight(ps.Manufacturer, " "), ps.SerialNumber, ps.FirmwareVersion, ps.PowerSupplyType, strconv.Itoa(bay), ps.Model).Set(watts)
+			}
 			if ps.Status.Health == "OK" || ps.Status.Health == "Ok" {
 				state = OK
 			} else if ps.Status.Health == "" {

--- a/exporter/handlers.go
+++ b/exporter/handlers.go
@@ -164,7 +164,7 @@ func (e *Exporter) exportPowerMetrics(body []byte) error {
 			}
 
 			(*pow)["supplyOutput"].WithLabelValues(ps.Name, e.ChassisSerialNumber, e.Model, strings.TrimRight(ps.Manufacturer, " "), ps.SerialNumber, ps.FirmwareVersion, ps.PowerSupplyType, strconv.Itoa(bay), ps.Model).Set(watts)
-			if ps.Status.Health == "OK" {
+			if ps.Status.Health == "OK" || ps.Status.Health == "Ok" {
 				state = OK
 			} else if ps.Status.Health == "" {
 				state = OK
@@ -445,10 +445,10 @@ func (e *Exporter) exportMemorySummaryMetrics(body []byte) error {
 	}
 	// Check memory status and convert string to numeric values
 	// Ignore memory summary if status is not present
-	if dlm.MemorySummary.Status.HealthRollup == "" {
-		return nil
-	} else if dlm.MemorySummary.Status.HealthRollup == "OK" {
+	if dlm.MemorySummary.Status.HealthRollup == "OK" || dlm.MemorySummary.Status.Health == "OK" {
 		state = OK
+	} else if dlm.MemorySummary.Status.HealthRollup == "" {
+		return nil
 	} else {
 		state = BAD
 	}

--- a/exporter/helpers.go
+++ b/exporter/helpers.go
@@ -441,48 +441,6 @@ func getAllDriveEndpoints(ctx context.Context, fqdn, initialUrl, host string, cl
 	return driveEndpoints, nil
 }
 
-func getFirmwareEndpoints(url, host string, client *retryablehttp.Client) (oem.Collection, error) {
-	var fwEpUrls oem.Collection
-	var resp *http.Response
-	var err error
-	retryCount := 0
-	req := common.BuildRequest(url, host)
-
-	resp, err = common.DoRequest(client, req)
-	if err != nil {
-		return fwEpUrls, err
-	}
-	defer resp.Body.Close()
-	if !(resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices) {
-		if resp.StatusCode == http.StatusNotFound {
-			for retryCount < 1 && resp.StatusCode == http.StatusNotFound {
-				time.Sleep(client.RetryWaitMin)
-				resp, err = common.DoRequest(client, req)
-				retryCount = retryCount + 1
-			}
-			if err != nil {
-				return fwEpUrls, err
-			} else if !(resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices) {
-				return fwEpUrls, fmt.Errorf("HTTP status %d", resp.StatusCode)
-			}
-		} else {
-			return fwEpUrls, fmt.Errorf("HTTP status %d", resp.StatusCode)
-		}
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fwEpUrls, fmt.Errorf("Error reading Response Body - " + err.Error())
-	}
-
-	err = json.Unmarshal(body, &fwEpUrls)
-	if err != nil {
-		return fwEpUrls, fmt.Errorf("Error Unmarshalling Memory Collection struct - " + err.Error())
-	}
-
-	return fwEpUrls, nil
-}
-
 func getProcessorEndpoints(url, host string, client *retryablehttp.Client) (oem.Collection, error) {
 	var processors oem.Collection
 	var resp *http.Response

--- a/exporter/helpers.go
+++ b/exporter/helpers.go
@@ -543,3 +543,48 @@ func checkUnique(s []string, str string) bool {
 	}
 	return true
 }
+
+// GetFirstNonEmptyURL returns the first non-empty URL from the provided list.
+func GetFirstNonEmptyURL(urls ...string) string {
+	for _, url := range urls {
+		if url != "" {
+			return url
+		}
+	}
+	return ""
+}
+
+// GetMemoryURL assigns the appropriate URL to the Memory field.
+func GetMemoryURL(sysResp oem.System) string {
+	return GetFirstNonEmptyURL(
+		sysResp.Memory.URL,
+		sysResp.Oem.Hpe.Links.Memory.URL,
+		sysResp.Oem.Hp.Links.Memory.URL,
+		sysResp.Oem.Hpe.LinksLower.Memory.URL,
+		sysResp.Oem.Hp.LinksLower.Memory.URL,
+	)
+}
+
+// GetSmartStorageURL assigns the appropriate URL to the SmartStorage field.
+func GetSmartStorageURL(sysResp oem.System) string {
+	ss := GetFirstNonEmptyURL(
+		sysResp.Oem.Hpe.Links.SmartStorage.URL,
+		sysResp.Oem.Hp.Links.SmartStorage.URL,
+		sysResp.Oem.Hpe.LinksLower.SmartStorage.URL,
+		sysResp.Oem.Hp.LinksLower.SmartStorage.URL,
+	)
+	if ss != "" {
+		ss = appendSlash(ss) + "ArrayControllers/"
+	}
+	return ss
+}
+
+// GetFirmwareInventoryURL assigns the appropriate URL to the FirmwareInventory field.
+func GetFirmwareInventoryURL(sysResp oem.System) string {
+	return GetFirstNonEmptyURL(
+		sysResp.Oem.Hpe.Links.FirmwareInventory.URL,
+		sysResp.Oem.Hp.Links.FirmwareInventory.URL,
+		sysResp.Oem.Hpe.LinksLower.FirmwareInventory.URL,
+		sysResp.Oem.Hp.LinksLower.FirmwareInventory.URL,
+	)
+}

--- a/oem/system.go
+++ b/oem/system.go
@@ -55,7 +55,7 @@ type SystemLinksUpper struct {
 type SystemLinksLower struct {
 	SmartStorage      HRef `json:"SmartStorage"`
 	FirmwareInventory HRef `json:"FirmwareInventory"`
-	Memory            Link `json:"Memory"`
+	Memory            HRef `json:"Memory"`
 }
 
 type SmartStorageBattery struct {

--- a/oem/system.go
+++ b/oem/system.go
@@ -46,11 +46,13 @@ type HpeSys struct {
 type SystemLinksUpper struct {
 	SmartStorage      Link `json:"SmartStorage"`
 	FirmwareInventory Link `json:"FirmwareInventory"`
+	Memory            Link `json:"Memory"`
 }
 
 type SystemLinksLower struct {
 	SmartStorage      HRef `json:"SmartStorage"`
 	FirmwareInventory HRef `json:"FirmwareInventory"`
+	Memory            Link `json:"Memory"`
 }
 
 type SmartStorageBattery struct {

--- a/oem/system.go
+++ b/oem/system.go
@@ -29,6 +29,8 @@ type System struct {
 	Memory            Link          `json:"Memory"`
 	Volumes           LinksWrapper  `json:"Volumes"`
 	FirmwareInventory LinksWrapper  `json:"FirmwareInventory"`
+	Storage           Link          `json:"Storage"`
+	UpdateService     Link          `json:"UpdateService"`
 }
 
 type OemSys struct {
@@ -81,4 +83,5 @@ type MemorySummary struct {
 // StatusMemory is the variable to determine if the memory is OK or not
 type StatusMemory struct {
 	HealthRollup string `json:"HealthRollup"`
+	Health       string `json:"Health"`
 }

--- a/oem/system.go
+++ b/oem/system.go
@@ -21,13 +21,14 @@ package oem
 // ServerManager contains the BIOS version and Serial number of the chassis,
 // we will also collect memory summary and storage battery metrics if present
 type System struct {
-	BiosVersion    string        `json:"BiosVersion"`
-	SerialNumber   string        `json:"SerialNumber"`
-	SystemHostname string        `json:"HostName"`
-	Oem            OemSys        `json:"Oem"`
-	MemorySummary  MemorySummary `json:"MemorySummary"`
-	Memory         Link          `json:"Memory"`
-	Volumes        LinksWrapper  `json:"Volumes"`
+	BiosVersion       string        `json:"BiosVersion"`
+	SerialNumber      string        `json:"SerialNumber"`
+	SystemHostname    string        `json:"HostName"`
+	Oem               OemSys        `json:"Oem"`
+	MemorySummary     MemorySummary `json:"MemorySummary"`
+	Memory            Link          `json:"Memory"`
+	Volumes           LinksWrapper  `json:"Volumes"`
+	FirmwareInventory LinksWrapper  `json:"FirmwareInventory"`
 }
 
 type OemSys struct {
@@ -80,5 +81,4 @@ type MemorySummary struct {
 // StatusMemory is the variable to determine if the memory is OK or not
 type StatusMemory struct {
 	HealthRollup string `json:"HealthRollup"`
-	Health       string `json:"Health"`
 }

--- a/oem/system.go
+++ b/oem/system.go
@@ -44,11 +44,13 @@ type HpeSys struct {
 }
 
 type SystemLinksUpper struct {
-	SmartStorage Link `json:"SmartStorage"`
+	SmartStorage      Link `json:"SmartStorage"`
+	FirmwareInventory Link `json:"FirmwareInventory"`
 }
 
 type SystemLinksLower struct {
-	SmartStorage HRef `json:"SmartStorage"`
+	SmartStorage      HRef `json:"SmartStorage"`
+	FirmwareInventory HRef `json:"FirmwareInventory"`
 }
 
 type SmartStorageBattery struct {

--- a/oem/system.go
+++ b/oem/system.go
@@ -80,4 +80,5 @@ type MemorySummary struct {
 // StatusMemory is the variable to determine if the memory is OK or not
 type StatusMemory struct {
 	HealthRollup string `json:"HealthRollup"`
+	Health       string `json:"Health"`
 }

--- a/oem/system.go
+++ b/oem/system.go
@@ -26,7 +26,8 @@ type System struct {
 	SystemHostname string        `json:"HostName"`
 	Oem            OemSys        `json:"Oem"`
 	MemorySummary  MemorySummary `json:"MemorySummary"`
-	Volumes        Link          `json:"Volumes"`
+	Memory         Link          `json:"Memory"`
+	Volumes        LinksWrapper  `json:"Volumes"`
 }
 
 type OemSys struct {


### PR DESCRIPTION
 - Added support for Super Micro Models. 
 - Refactored LinksWrapper for UnmarshalJSON to handle single objects
 - Refactored Firmware Metrics: Enhanced to handle more issues when the system/firmware is not available.
 - Refactored Dimm Metrics: Improved handling for better performance and reliability.
 - Refactored Dimm, Firmware Metrics, and Storage URLs to be accessed via helpers.

This PR addresses issue https://github.com/Comcast/fishymetrics/issues/87