### PR TITLE
add a nil reference check during retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ log is based on the [Keep a CHANGELOG](http://keepachangelog.com/) project.
 
 ## Unreleased
 
+## Fixed
+
+- nil pointer dereference during a scrape [#97](https://github.com/Comcast/fishymetrics/issues/97)
+
+## [0.12.0]
+
 ## Added
 
 - Add ability to reference different vault paths for credential retrieval [#25](https://github.com/Comcast/fishymetrics/issues/25)

--- a/common/util.go
+++ b/common/util.go
@@ -56,6 +56,9 @@ func Fetch(uri, host, profile string, client *retryablehttp.Client) func() ([]by
 				for retryCount < 3 && resp.StatusCode == http.StatusNotFound {
 					time.Sleep(client.RetryWaitMin)
 					resp, err = DoRequest(client, req)
+					if err != nil {
+						return nil, err
+					}
 					retryCount = retryCount + 1
 				}
 				if err != nil {

--- a/exporter/moonshot/exporter.go
+++ b/exporter/moonshot/exporter.go
@@ -212,6 +212,9 @@ func fetch(uri, device, metricType, host, profile string, client *retryablehttp.
 				for retryCount < 3 && resp.StatusCode == http.StatusNotFound {
 					time.Sleep(client.RetryWaitMin)
 					resp, err = common.DoRequest(client, req)
+					if err != nil {
+						return nil, device, metricType, err
+					}
 					retryCount = retryCount + 1
 				}
 				if err != nil {


### PR DESCRIPTION
fixes - #97 

What was happening was, occasionally a host would return a `HTTP 404` response which would then place us in the retry loop, but if any of the retries failed where no response was returned, then our `resp` variable would not be set and that would cause a nil pointer exception.