### PR TITLE
Modify fishymetrics port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ log is based on the [Keep a CHANGELOG](http://keepachangelog.com/) project.
 
 ## Unreleased
 
+## [0.12.1]
+
 ## Fixed
 
 - nil pointer dereference during a scrape [#97](https://github.com/Comcast/fishymetrics/issues/97)
@@ -14,6 +16,7 @@ log is based on the [Keep a CHANGELOG](http://keepachangelog.com/) project.
 
  - Removed trailing spaces in label values [#96](https://github.com/Comcast/fishymetrics/issues/96)
  - Add missing language fences to README [#95](https://github.com/Comcast/fishymetrics/pull/95)
+ - Set Fishymetrics port default to 10023 [#100](https://github.com/Comcast/fishymetrics/issues/100)
 
 ## [0.12.0]
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Flags:
       --log.file-max-age="1"      max file age in days before they are rotated if log-method is file
       --vector.endpoint="http://0.0.0.0:4444"
                                 vector endpoint to send structured json logs to
-      --port="9533"             exporter port
+      --port="10023"             exporter port
       --vault.addr="https://vault.com"
                                 Vault instance address to get chassis credentials from
       --vault.role-id=""        Vault Role ID for AppRole
@@ -65,7 +65,7 @@ BMC_USERNAME=<string>
 BMC_PASSWORD=<string>
 BMC_TIMEOUT=<duration> (Default: 15s)
 BMC_SCHEME=<string> (Default: https)
-EXPORTER_PORT=<int> (Default: 9533)
+EXPORTER_PORT=<int> (Default: 10023)
 LOG_PATH=<string> (Default: /var/log/fishymetrics)
 VAULT_ADDRESS=<string>
 VAULT_ROLE_ID=<string>
@@ -104,7 +104,7 @@ _if deployed on ones localhost_
 </aside>
 
 ```bash
-curl http://localhost:9533/info
+curl http://localhost:10023/info
 ```
 
 ### metrics URL
@@ -116,7 +116,7 @@ _if deployed on ones localhost_
 </aside>
 
 ```bash
-curl http://localhost:9533/metrics
+curl http://localhost:10023/metrics
 ```
 
 ### redfish API `/scrape`
@@ -124,19 +124,19 @@ curl http://localhost:9533/metrics
 To test a scrape of a host's redfish API, you can curl `fishymetrics`
 
 ```bash
-curl 'http://localhost:9533/scrape?model=<model-name>&target=1.2.3.4'
+curl 'http://localhost:10023/scrape?model=<model-name>&target=1.2.3.4'
 ```
 
 If you have a credential profile configured you can add the extra URL query parameter
 
 ```bash
-curl 'http://localhost:9533/scrape?model=<model-name>&target=1.2.3.4&credential_profile=<profile-name>'
+curl 'http://localhost:10023/scrape?model=<model-name>&target=1.2.3.4&credential_profile=<profile-name>'
 ```
 
 There is plugin support which is passed a comma separated list of strings
 
 ```bash
-curl 'http://localhost:9533/scrape?model=<model-name>&target=1.2.3.4&plugins=example1,example2'
+curl 'http://localhost:10023/scrape?model=<model-name>&target=1.2.3.4&plugins=example1,example2'
 ```
 
 ### Docker
@@ -186,6 +186,7 @@ scrape_configs:
           foo: bar
     metrics_path: /scrape
     scrape_interval: 5m
+    scrape_timeout: 4m  # Time limit to allow gathering metrics from multiple hardware components
     params:
       model: ["dl360"]
     relabel_configs:

--- a/cmd/fishymetrics/main.go
+++ b/cmd/fishymetrics/main.go
@@ -69,7 +69,7 @@ var (
 	logFileMaxBackups  = a.Flag("log.file-max-backups", "max file backups before they are rotated if log-method is file").Default("1").Envar("LOG_FILE_MAX_BACKUPS").String()
 	logFileMaxAge      = a.Flag("log.file-max-age", "max file age in days before they are rotated if log-method is file").Default("1").Envar("LOG_FILE_MAX_AGE").String()
 	vectorEndpoint     = a.Flag("vector.endpoint", "vector endpoint to send structured json logs to").Default("http://0.0.0.0:4444").Envar("VECTOR_ENDPOINT").String()
-	exporterPort       = a.Flag("port", "exporter port").Default("9533").Envar("EXPORTER_PORT").String()
+	exporterPort       = a.Flag("port", "exporter port").Default("10023").Envar("EXPORTER_PORT").String()
 	vaultAddr          = a.Flag("vault.addr", "Vault instance address to get chassis credentials from").Default("https://vault.com").Envar("VAULT_ADDRESS").String()
 	vaultRoleId        = a.Flag("vault.role-id", "Vault Role ID for AppRole").Default("").Envar("VAULT_ROLE_ID").String()
 	vaultSecretId      = a.Flag("vault.secret-id", "Vault Secret ID for AppRole").Default("").Envar("VAULT_SECRET_ID").String()

--- a/helm/fishymetrics/Chart.yaml
+++ b/helm/fishymetrics/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.12.0
+appVersion: 0.12.1
 description: A Helm chart for a General Purpose Chassis Monitoring Exporter using the redfish API
 maintainers:
   - email: derrick.dacosta@protonmail.com
@@ -7,4 +7,4 @@ maintainers:
   - email: ibrahimkk.moideen@gmail.com
     name: Ibrahim Khalilullah Khan
 name: fishymetrics
-version: 0.10.3
+version: 0.10.4

--- a/helm/fishymetrics/README.md
+++ b/helm/fishymetrics/README.md
@@ -30,10 +30,10 @@ The following table lists the configurable parameters of the fishymetrics chart 
 | Parameter                                                   | Description                                                                                | Default                   |
 | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ------------------------- |
 | `image.repo`                                                | container image repo for fishymetrics                                                      | `"comcast/fishymetrics"`  |
-| `image.tag`                                                 | container image tag for fishymetrics                                                       | `"0.12.0"`                |
+| `image.tag`                                                 | container image tag for fishymetrics                                                       | `"0.12.1"`                |
 | `image.pullPolicy`                                          | container image pull policy                                                                | `"IfNotPresent"`          |
 | `replicas`                                                  | number of replica sets to initially deploy                                                 | `1`                       |
-| `exporter.port`                                             | exporter port to listen on                                                                 | `9533`                    |
+| `exporter.port`                                             | exporter port to listen on                                                                 | `10023`                    |
 | `log.level`                                                 | log level verbosity                                                                        | `"info"`                  |
 | `log.method`                                                | alternative method for logging in addition to stdout                                       | `""`                      |
 | `log.filePath`                                              | directory path where log files are written                                                 | `"/var/log/fishymetrics"` |

--- a/helm/fishymetrics/values.yaml
+++ b/helm/fishymetrics/values.yaml
@@ -1,12 +1,12 @@
 image:
   repo: comcast/fishymetrics
-  tag: 0.12.0
+  tag: 0.12.1
   pullPolicy: IfNotPresent
 
 replicas: 1
 
 exporter:
-  port: "9533"
+  port: "10023"
 
 log:
   level: "info"


### PR DESCRIPTION
Fix for #100 

Set the default port number to "10023" as referenced in [Prometheus Default port allocations](https://github.com/prometheus/prometheus/wiki/Default-port-allocations).