### PR TITLE
set generic metric names from moonshot exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ log is based on the [Keep a CHANGELOG](http://keepachangelog.com/) project.
 ## Updated
 
 - increase security context for kubernetes helm chart deployment [#102](https://github.com/Comcast/fishymetrics/issues/102)
+- metric names in moonshot exporter to generic names as seen in other models [#106](https://github.com/Comcast/fishymetrics/issues/106)
 
 ## [0.12.1]
 

--- a/exporter/moonshot/metrics.go
+++ b/exporter/moonshot/metrics.go
@@ -40,30 +40,30 @@ func NewDeviceMetrics() *map[string]*metrics {
 		}
 
 		ThermalMetrics = &metrics{
-			"fanSpeed":          newServerMetric("thermal_fan_speed", "Current fan speed in the unit of percentage, possible values are 0 - 100", nil, []string{"name"}),
-			"fanStatus":         newServerMetric("thermal_fan_status", "Current fan status 1 = OK, 0 = BAD", nil, []string{"name"}),
-			"sensorTemperature": newServerMetric("thermal_sensor_temperature", "Current sensor temperature reading in Celsius", nil, []string{"name"}),
-			"sensorStatus":      newServerMetric("thermal_sensor_status", "Current sensor status 1 = OK, 0 = BAD", nil, []string{"name"}),
+			"fanSpeed":          newServerMetric("redfish_thermal_fan_speed", "Current fan speed in the unit of percentage, possible values are 0 - 100", nil, []string{"name"}),
+			"fanStatus":         newServerMetric("redfish_thermal_fan_status", "Current fan status 1 = OK, 0 = BAD", nil, []string{"name"}),
+			"sensorTemperature": newServerMetric("redfish_thermal_sensor_temperature", "Current sensor temperature reading in Celsius", nil, []string{"name"}),
+			"sensorStatus":      newServerMetric("redfish_thermal_sensor_status", "Current sensor status 1 = OK, 0 = BAD", nil, []string{"name"}),
 		}
 
 		PowerMetrics = &metrics{
-			"supplyOutput":        newServerMetric("power_supply_output", "Power supply output in watts", nil, []string{"name", "sparePartNumber"}),
-			"supplyStatus":        newServerMetric("power_supply_status", "Current power supply status 1 = OK, 0 = BAD", nil, []string{"name", "sparePartNumber"}),
-			"supplyTotalConsumed": newServerMetric("power_supply_total_consumed", "Total output of all power supplies in watts", nil, []string{}),
-			"supplyTotalCapacity": newServerMetric("power_supply_total_capacity", "Total output capacity of all the power supplies", nil, []string{}),
+			"supplyOutput":        newServerMetric("redfish_power_supply_output", "Power supply output in watts", nil, []string{"name", "sparePartNumber"}),
+			"supplyStatus":        newServerMetric("redfish_power_supply_status", "Current power supply status 1 = OK, 0 = BAD", nil, []string{"name", "sparePartNumber"}),
+			"supplyTotalConsumed": newServerMetric("redfish_power_supply_total_consumed", "Total output of all power supplies in watts", nil, []string{}),
+			"supplyTotalCapacity": newServerMetric("redfish_power_supply_total_capacity", "Total output capacity of all the power supplies", nil, []string{}),
 		}
 
 		SwitchMetrics = &metrics{
-			"moonshotSwitchStatus": newServerMetric("moonshot_switch_status", "Current Moonshot switch status 1 = OK, 0 = BAD", nil, []string{"name", "serialNumber"}),
+			"moonshotSwitchStatus": newServerMetric("redfish_moonshot_switch_status", "Current Moonshot switch status 1 = OK, 0 = BAD", nil, []string{"name", "serialNumber"}),
 		}
 
 		SwitchThermalMetrics = &metrics{
-			"moonshotSwitchSensorTemperature": newServerMetric("moonshot_switch_thermal_sensor_temperature", "Current sensor temperature reading in Celsius", nil, []string{"name"}),
-			"moonshotSwitchSensorStatus":      newServerMetric("moonshot_switch_thermal_sensor_status", "Current sensor status 1 = OK, 0 = BAD", nil, []string{"name"}),
+			"moonshotSwitchSensorTemperature": newServerMetric("redfish_moonshot_switch_thermal_sensor_temperature", "Current sensor temperature reading in Celsius", nil, []string{"name"}),
+			"moonshotSwitchSensorStatus":      newServerMetric("redfish_moonshot_switch_thermal_sensor_status", "Current sensor status 1 = OK, 0 = BAD", nil, []string{"name"}),
 		}
 
 		SwitchPowerMetrics = &metrics{
-			"moonshotSwitchSupplyOutput": newServerMetric("moonshot_switch_power_supply_output", "Power supply output in watts", nil, []string{"name"}),
+			"moonshotSwitchSupplyOutput": newServerMetric("redfish_moonshot_switch_power_supply_output", "Power supply output in watts", nil, []string{"name"}),
 		}
 
 		Metrics = &map[string]*metrics{


### PR DESCRIPTION
Update metric names from moonshot exporter to generic names as seen in other models.

Results:
```
# HELP redfish_moonshot_switch_power_supply_output Power supply output in watts
# TYPE redfish_moonshot_switch_power_supply_output gauge
redfish_moonshot_switch_power_supply_output{name="switch-a-PowerMetrics"} 54
redfish_moonshot_switch_power_supply_output{name="switch-b-PowerMetrics"} 53
# HELP redfish_moonshot_switch_status Current Moonshot switch status 1 = OK, 0 = BAD
# TYPE redfish_moonshot_switch_status gauge
redfish_moonshot_switch_status{name="Switch A",serialNumber="##redacted##"} 1
redfish_moonshot_switch_status{name="Switch B",serialNumber="##redacted##"} 1
# HELP redfish_moonshot_switch_thermal_sensor_status Current sensor status 1 = OK, 0 = BAD
# TYPE redfish_moonshot_switch_thermal_sensor_status gauge
redfish_moonshot_switch_thermal_sensor_status{name="switch-a-ThermalMetrics"} 1
redfish_moonshot_switch_thermal_sensor_status{name="switch-b-ThermalMetrics"} 1
# HELP redfish_moonshot_switch_thermal_sensor_temperature Current sensor temperature reading in Celsius
# TYPE redfish_moonshot_switch_thermal_sensor_temperature gauge
redfish_moonshot_switch_thermal_sensor_temperature{name="switch-a-ThermalMetrics"} 33
redfish_moonshot_switch_thermal_sensor_temperature{name="switch-b-ThermalMetrics"} 32
# HELP redfish_power_supply_output Power supply output in watts
# TYPE redfish_power_supply_output gauge
redfish_power_supply_output{name="Power Supply 1",sparePartNumber="794734-001"} 566
redfish_power_supply_output{name="Power Supply 2",sparePartNumber="794734-001"} 546
redfish_power_supply_output{name="Power Supply 3",sparePartNumber="794734-001"} 563
redfish_power_supply_output{name="Power Supply 4",sparePartNumber="794734-001"} 546
# HELP redfish_power_supply_status Current power supply status 1 = OK, 0 = BAD
# TYPE redfish_power_supply_status gauge
redfish_power_supply_status{name="Power Supply 1",sparePartNumber="794734-001"} 1
redfish_power_supply_status{name="Power Supply 2",sparePartNumber="794734-001"} 1
redfish_power_supply_status{name="Power Supply 3",sparePartNumber="794734-001"} 1
redfish_power_supply_status{name="Power Supply 4",sparePartNumber="794734-001"} 1
# HELP redfish_power_supply_total_capacity Total output capacity of all the power supplies
# TYPE redfish_power_supply_total_capacity gauge
redfish_power_supply_total_capacity 5752
# HELP redfish_power_supply_total_consumed Total output of all power supplies in watts
# TYPE redfish_power_supply_total_consumed gauge
redfish_power_supply_total_consumed 2221
# HELP redfish_thermal_fan_speed Current fan speed in the unit of percentage, possible values are 0 - 100
# TYPE redfish_thermal_fan_speed gauge
redfish_thermal_fan_speed{name="Fan 1"} 74
redfish_thermal_fan_speed{name="Fan 2"} 74
redfish_thermal_fan_speed{name="Fan 3"} 74
redfish_thermal_fan_speed{name="Fan 4"} 74
redfish_thermal_fan_speed{name="Fan 5"} 74
# HELP redfish_thermal_fan_status Current fan status 1 = OK, 0 = BAD
# TYPE redfish_thermal_fan_status gauge
redfish_thermal_fan_status{name="Fan 1"} 1
redfish_thermal_fan_status{name="Fan 2"} 1
redfish_thermal_fan_status{name="Fan 3"} 1
redfish_thermal_fan_status{name="Fan 4"} 1
redfish_thermal_fan_status{name="Fan 5"} 1
# HELP redfish_thermal_sensor_status Current sensor status 1 = OK, 0 = BAD
# TYPE redfish_thermal_sensor_status gauge
redfish_thermal_sensor_status{name="Inlet Temp"} 1
redfish_thermal_sensor_status{name="Net Brd In"} 1
redfish_thermal_sensor_status{name="Net Brd L Exh"} 1
redfish_thermal_sensor_status{name="Net Brd R Exh"} 1
redfish_thermal_sensor_status{name="Network Zone"} 1
redfish_thermal_sensor_status{name="Power Supply 1"} 1
redfish_thermal_sensor_status{name="Power Supply 2"} 1
redfish_thermal_sensor_status{name="Power Supply 3"} 1
redfish_thermal_sensor_status{name="Power Supply 4"} 1
redfish_thermal_sensor_status{name="Sys Board Exh"} 1
redfish_thermal_sensor_status{name="iLO Board Exh"} 1
redfish_thermal_sensor_status{name="iLO Board L In"} 1
redfish_thermal_sensor_status{name="iLO Board R In"} 1
redfish_thermal_sensor_status{name="iLO Zone"} 1
# HELP redfish_thermal_sensor_temperature Current sensor temperature reading in Celsius
# TYPE redfish_thermal_sensor_temperature gauge
redfish_thermal_sensor_temperature{name="Inlet Temp"} 19
redfish_thermal_sensor_temperature{name="Net Brd In"} 30
redfish_thermal_sensor_temperature{name="Net Brd L Exh"} 34
redfish_thermal_sensor_temperature{name="Net Brd R Exh"} 35
redfish_thermal_sensor_temperature{name="Network Zone"} 38
redfish_thermal_sensor_temperature{name="Power Supply 1"} 26
redfish_thermal_sensor_temperature{name="Power Supply 2"} 26
redfish_thermal_sensor_temperature{name="Power Supply 3"} 28
redfish_thermal_sensor_temperature{name="Power Supply 4"} 30
redfish_thermal_sensor_temperature{name="Sys Board Exh"} 27
redfish_thermal_sensor_temperature{name="iLO Board Exh"} 33
redfish_thermal_sensor_temperature{name="iLO Board L In"} 32
redfish_thermal_sensor_temperature{name="iLO Board R In"} 32
redfish_thermal_sensor_temperature{name="iLO Zone"} 36
# HELP up was the last scrape of fishymetrics successful.
# TYPE up gauge
up 1
```