### PR TITLE
Fix various leaks

### DIFF
--- a/exporter/helpers.go
+++ b/exporter/helpers.go
@@ -40,7 +40,7 @@ func getMemberUrls(url, host string, client *retryablehttp.Client) ([]string, er
 	if err != nil {
 		return urls, err
 	}
-	defer resp.Body.Close()
+	defer common.EmptyAndCloseBody(resp)
 	if !(resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices) {
 		if resp.StatusCode == http.StatusUnauthorized {
 			return urls, common.ErrInvalidCredential
@@ -77,7 +77,7 @@ func getSystemEndpoints(chassisUrls []string, host string, client *retryablehttp
 		if err != nil {
 			return sysEnd, err
 		}
-		defer resp.Body.Close()
+		defer common.EmptyAndCloseBody(resp)
 		if !(resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices) {
 			if resp.StatusCode == http.StatusUnauthorized {
 				return sysEnd, common.ErrInvalidCredential
@@ -218,7 +218,7 @@ func getSystemsMetadata(url, host string, client *retryablehttp.Client) (oem.Sys
 	if err != nil {
 		return sys, err
 	}
-	defer resp.Body.Close()
+	defer common.EmptyAndCloseBody(resp)
 	if !(resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices) {
 		return sys, fmt.Errorf("HTTP status %d", resp.StatusCode)
 	}
@@ -247,15 +247,16 @@ func getDIMMEndpoints(url, host string, client *retryablehttp.Client) (oem.Colle
 	if err != nil {
 		return dimms, err
 	}
-	defer resp.Body.Close()
+	defer common.EmptyAndCloseBody(resp)
 	if !(resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices) {
 		if resp.StatusCode == http.StatusNotFound {
-			for retryCount < 1 && resp.StatusCode == http.StatusNotFound {
+			for retryCount < 3 && resp.StatusCode == http.StatusNotFound {
 				time.Sleep(client.RetryWaitMin)
 				resp, err = common.DoRequest(client, req)
 				if err != nil {
 					return dimms, err
 				}
+				defer common.EmptyAndCloseBody(resp)
 				retryCount = retryCount + 1
 			}
 			if err != nil {
@@ -294,7 +295,7 @@ func getDriveEndpoint(url, host string, client *retryablehttp.Client) (oem.Gener
 	if err != nil {
 		return drive, err
 	}
-	defer resp.Body.Close()
+	defer common.EmptyAndCloseBody(resp)
 	if !(resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices) {
 		if resp.StatusCode == http.StatusNotFound {
 			for retryCount < 3 && resp.StatusCode == http.StatusNotFound {
@@ -303,6 +304,7 @@ func getDriveEndpoint(url, host string, client *retryablehttp.Client) (oem.Gener
 				if err != nil {
 					return drive, err
 				}
+				defer common.EmptyAndCloseBody(resp)
 				retryCount = retryCount + 1
 			}
 			if err != nil {
@@ -473,7 +475,7 @@ func getProcessorEndpoints(url, host string, client *retryablehttp.Client) (oem.
 	if err != nil {
 		return processors, err
 	}
-	defer resp.Body.Close()
+	defer common.EmptyAndCloseBody(resp)
 	if !(resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices) {
 		if resp.StatusCode == http.StatusNotFound {
 			for retryCount < 3 && resp.StatusCode == http.StatusNotFound {
@@ -482,6 +484,7 @@ func getProcessorEndpoints(url, host string, client *retryablehttp.Client) (oem.
 				if err != nil {
 					return processors, err
 				}
+				defer common.EmptyAndCloseBody(resp)
 				retryCount = retryCount + 1
 			}
 			if err != nil {

--- a/exporter/moonshot/exporter.go
+++ b/exporter/moonshot/exporter.go
@@ -206,7 +206,7 @@ func fetch(uri, device, metricType, host, profile string, client *retryablehttp.
 		if err != nil {
 			return nil, device, metricType, err
 		}
-		defer resp.Body.Close()
+		defer common.EmptyAndCloseBody(resp)
 		if !(resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices) {
 			if resp.StatusCode == http.StatusNotFound {
 				for retryCount < 3 && resp.StatusCode == http.StatusNotFound {
@@ -215,6 +215,7 @@ func fetch(uri, device, metricType, host, profile string, client *retryablehttp.
 					if err != nil {
 						return nil, device, metricType, err
 					}
+					defer common.EmptyAndCloseBody(resp)
 					retryCount = retryCount + 1
 				}
 				if err != nil {
@@ -239,6 +240,7 @@ func fetch(uri, device, metricType, host, profile string, client *retryablehttp.
 
 				time.Sleep(client.RetryWaitMin)
 				resp, err = common.DoRequest(client, req)
+				defer common.EmptyAndCloseBody(resp)
 				if err != nil {
 					return nil, device, metricType, fmt.Errorf("HTTP status %d", resp.StatusCode)
 				}

--- a/plugins/nuova/helpers.go
+++ b/plugins/nuova/helpers.go
@@ -82,12 +82,13 @@ func checkRaidController(url, host string, client *retryablehttp.Client) (bool, 
 	defer resp.Body.Close()
 	if !(resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices) {
 		if resp.StatusCode == http.StatusNotFound {
-			for retryCount < 1 && resp.StatusCode == http.StatusNotFound {
+			for retryCount < 3 && resp.StatusCode == http.StatusNotFound {
 				time.Sleep(client.RetryWaitMin)
 				resp, err = common.DoRequest(client, req)
 				if err != nil {
 					return false, nil
 				}
+				defer common.EmptyAndCloseBody(resp)
 				retryCount = retryCount + 1
 			}
 			if err != nil {
@@ -133,7 +134,7 @@ func IMCPost(uri, classId, cookie string, client *retryablehttp.Client) ([]byte,
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer common.EmptyAndCloseBody(resp)
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -151,7 +152,7 @@ func IMCLogin(uri, target string, client *retryablehttp.Client) (string, error) 
 	if err != nil {
 		return aaaLogin.OutCookie, err
 	}
-	defer resp.Body.Close()
+	defer common.EmptyAndCloseBody(resp)
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -177,7 +178,7 @@ func IMCLogout(uri, cookie string, client *retryablehttp.Client) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer common.EmptyAndCloseBody(resp)
 
 	return nil
 }


### PR DESCRIPTION
When running fishymetrics in our own infrastructure we noticed that the memory usage was greatly increasing (at a steady pace)
as you can see here:
![image](https://github.com/user-attachments/assets/18c57193-e510-4285-93f2-7583cdd23306)
*Left: deployed as-is, middle: after SystemD memory accounting and limiting, right: with the fix*

The specificity of our configuration is that we are scrapping around 6000 servers on this instance (there are actually two instances load balanced, so let's say 3000 averaged) and that a non negligible portion is in error(either because of a broken BMC firmware than cannot properly be parsed by Fishymetrics, or just because they are unreachable). There was two issues:
1. A channel is awaited during the scrapping, but if, for whatever reason, there was a fetching/parsing error during the handling of the task, then we have a leaking go routine, repeating at every scrap
2. Some body were not closed when requesting (due to the structure of the code) and in some cases the body was not consumed, preventing the connections from being reused (see the associated commit, Prometheus had a similar issue in the past)

With those two fixes, we get the memory usage under 3GB for those 3000 servers, which seems much more reasonable to me :)