### PR TITLE
linter, spelling nits + panic fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@ log is based on the [Keep a CHANGELOG](http://keepachangelog.com/) project.
 ## Fixed
 
 - Cisco UCS C220 - add additional edge cases when collecting memory metrics [#2](https://github.com/Comcast/fishymetrics/issues/2)
-- null pointer derefence errors when using incorrect credentials [#36](https://github.com/Comcast/fishymetrics/issues/36)
+- null pointer dereference errors when using incorrect credentials [#36](https://github.com/Comcast/fishymetrics/issues/36)
 - incorrect /Memory path for HPE hosts [#49](https://github.com/Comcast/fishymetrics/issues/49)
 - Thermal Summary, Power total consumed for Cisco servers and Chassis, memory metrics for Gen9 server models [#53](https://github.com/Comcast/fishymetrics/issues/53)
 - Firmware gathering endpoint update and add device info to other HP models [#55](https://github.com/Comcast/fishymetrics/issues/55)
@@ -186,7 +186,7 @@ log is based on the [Keep a CHANGELOG](http://keepachangelog.com/) project.
 
 ## Changed
 
-- incease scrape timeout to 90 seconds for c220 devices
+- increase scrape timeout to 90 seconds for c220 devices
 - update helm chart to reflect updated env vars
 
 ## Fixed
@@ -258,7 +258,7 @@ log is based on the [Keep a CHANGELOG](http://keepachangelog.com/) project.
 
 ## Fixed
 
-- Metrics are not reseting the way it used to
+- Metrics are not resetting the way it used to
 - Web UI not routing correctly when app is behind nginx-ingress
 
 ## [0.3.0]

--- a/cmd/fishymetrics/templates.go
+++ b/cmd/fishymetrics/templates.go
@@ -16,10 +16,6 @@
 
 package main
 
-type indexAppData struct {
-	Hostname string
-}
-
 const postPayload string = "`{\"host\": \"${host}\"}`"
 
 const indexTmpl string = `<html>

--- a/common/credentials.go
+++ b/common/credentials.go
@@ -141,7 +141,7 @@ func (c *ChassisCredentials) GetCredentials(ctx context.Context, profile, target
 		return nil, fmt.Errorf("vault client not configured")
 	}
 
-	// check that atleast 1 profile is present
+	// check that at least 1 profile is present
 	if len(c.Profiles) < 1 {
 		return nil, fmt.Errorf("no credential profiles configured")
 	}

--- a/common/util.go
+++ b/common/util.go
@@ -85,7 +85,7 @@ func Fetch(uri, host, profile string, client *retryablehttp.Client) func() ([]by
 				time.Sleep(client.RetryWaitMin)
 				resp, err = DoRequest(client, req)
 				if err != nil {
-					return nil, fmt.Errorf("Retry DoRequest failed - " + err.Error())
+					return nil, fmt.Errorf("retry DoRequest failed - %v", err)
 				}
 				defer EmptyAndCloseBody(resp)
 				if resp.StatusCode == http.StatusUnauthorized {
@@ -98,7 +98,7 @@ func Fetch(uri, host, profile string, client *retryablehttp.Client) func() ([]by
 
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
-			return nil, fmt.Errorf("Error reading Response Body - " + err.Error())
+			return nil, fmt.Errorf("error reading Response Body - %v", err)
 		}
 		return body, err
 	}

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,6 +1,6 @@
 # plugins
 
-Plugins are a way to extend the capabilities of fishymetrics, by allowing the exporter to execute custom code after all the initializations are complete for a devices standard redfish metrics scrape. The main purpose for plugins is to collect component metrics data that is inaccessible using the prefered redfish API endpoints. Below is an example of how to create a custom plugin.
+Plugins are a way to extend the capabilities of fishymetrics, by allowing the exporter to execute custom code after all the initializations are complete for a devices standard redfish metrics scrape. The main purpose for plugins is to collect component metrics data that is inaccessible using the preferred redfish API endpoints. Below is an example of how to create a custom plugin.
 
 ## directory location
 

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -531,7 +531,7 @@ func (e *Exporter) collectMetrics(metrics chan<- prometheus.Metric) {
 func (e *Exporter) scrape() {
 	state := uint8(1)
 
-	// Concurrently call the endpoints to help prevent reaching the maxiumum number of 4 simultaneous sessions
+	// Concurrently call the endpoints to help prevent reaching the maximum number of 4 simultaneous sessions
 	e.pool.Run()
 	for _, task := range e.pool.Tasks {
 		var err error

--- a/exporter/handlers.go
+++ b/exporter/handlers.go
@@ -471,7 +471,7 @@ func (e *Exporter) exportMemorySummaryMetrics(body []byte) error {
 	return nil
 }
 
-// exportStorageBattery collects the smart storge battery metrics in json format and sets the prometheus guage
+// exportStorageBattery collects the smart storage battery metrics in json format and sets the prometheus gauge
 func (e *Exporter) exportStorageBattery(body []byte) error {
 
 	var state float64
@@ -647,7 +647,7 @@ func (e *Exporter) exportProcessorMetrics(body []byte) error {
 	return nil
 }
 
-// exportFirmwareInventoryMetrics collects the inventory component's firmware metrics in json format and sets the prometheus guages
+// exportFirmwareInventoryMetrics collects the inventory component's firmware metrics in json format and sets the prometheus gauges
 func (e *Exporter) exportFirmwareInventoryMetrics(body []byte) error {
 	var fwcomponent oem.ILO4Firmware
 	var component = (*e.DeviceMetrics)["firmwareInventoryMetrics"]
@@ -674,7 +674,7 @@ func (e *Exporter) exportFirmwareInventoryMetrics(body []byte) error {
 	return nil
 }
 
-// exportIloSelfTest collects the iLO Self Test Results metrics in json format and sets the prometheus guage
+// exportIloSelfTest collects the iLO Self Test Results metrics in json format and sets the prometheus gauge
 func (e *Exporter) exportIloSelfTest(body []byte) error {
 
 	var state float64

--- a/exporter/helpers.go
+++ b/exporter/helpers.go
@@ -34,8 +34,10 @@ import (
 func getMemberUrls(url, host string, client *retryablehttp.Client) ([]string, error) {
 	var coll oem.Collection
 	var urls []string
-	req := common.BuildRequest(url, host)
-
+	req, err := common.BuildRequest(url, host)
+	if err != nil {
+		return urls, err
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return urls, err
@@ -71,8 +73,10 @@ func getSystemEndpoints(chassisUrls []string, host string, client *retryablehttp
 	var sysEnd SystemEndpoints
 
 	for _, url := range chassisUrls {
-		req := common.BuildRequest(url, host)
-
+		req, err := common.BuildRequest(url, host)
+		if err != nil {
+			return sysEnd, err
+		}
 		resp, err := client.Do(req)
 		if err != nil {
 			return sysEnd, err
@@ -212,8 +216,10 @@ func getSystemEndpoints(chassisUrls []string, host string, client *retryablehttp
 
 func getSystemsMetadata(url, host string, client *retryablehttp.Client) (oem.System, error) {
 	var sys oem.System
-	req := common.BuildRequest(url, host)
-
+	req, err := common.BuildRequest(url, host)
+	if err != nil {
+		return sys, err
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return sys, err
@@ -238,12 +244,12 @@ func getSystemsMetadata(url, host string, client *retryablehttp.Client) (oem.Sys
 
 func getDIMMEndpoints(url, host string, client *retryablehttp.Client) (oem.Collection, error) {
 	var dimms oem.Collection
-	var resp *http.Response
-	var err error
 	retryCount := 0
-	req := common.BuildRequest(url, host)
-
-	resp, err = common.DoRequest(client, req)
+	req, err := common.BuildRequest(url, host)
+	if err != nil {
+		return dimms, err
+	}
+	resp, err := common.DoRequest(client, req)
 	if err != nil {
 		return dimms, err
 	}
@@ -257,7 +263,7 @@ func getDIMMEndpoints(url, host string, client *retryablehttp.Client) (oem.Colle
 					return dimms, err
 				}
 				defer common.EmptyAndCloseBody(resp)
-				retryCount = retryCount + 1
+				retryCount++
 			}
 			if err != nil {
 				return dimms, err
@@ -287,11 +293,12 @@ func getDIMMEndpoints(url, host string, client *retryablehttp.Client) (oem.Colle
 // This is used to find the final drive endpoints to append to the task pool for final scraping.
 func getDriveEndpoint(url, host string, client *retryablehttp.Client) (oem.GenericDrive, error) {
 	var drive oem.GenericDrive
-	var resp *http.Response
-	var err error
 	retryCount := 0
-	req := common.BuildRequest(url, host)
-	resp, err = common.DoRequest(client, req)
+	req, err := common.BuildRequest(url, host)
+	if err != nil {
+		return drive, err
+	}
+	resp, err := common.DoRequest(client, req)
 	if err != nil {
 		return drive, err
 	}
@@ -305,7 +312,7 @@ func getDriveEndpoint(url, host string, client *retryablehttp.Client) (oem.Gener
 					return drive, err
 				}
 				defer common.EmptyAndCloseBody(resp)
-				retryCount = retryCount + 1
+				retryCount++
 			}
 			if err != nil {
 				return drive, err
@@ -466,12 +473,12 @@ func getAllDriveEndpoints(ctx context.Context, fqdn, initialUrl, host string, cl
 
 func getProcessorEndpoints(url, host string, client *retryablehttp.Client) (oem.Collection, error) {
 	var processors oem.Collection
-	var resp *http.Response
-	var err error
 	retryCount := 0
-	req := common.BuildRequest(url, host)
-
-	resp, err = common.DoRequest(client, req)
+	req, err := common.BuildRequest(url, host)
+	if err != nil {
+		return processors, err
+	}
+	resp, err := common.DoRequest(client, req)
 	if err != nil {
 		return processors, err
 	}
@@ -485,7 +492,7 @@ func getProcessorEndpoints(url, host string, client *retryablehttp.Client) (oem.
 					return processors, err
 				}
 				defer common.EmptyAndCloseBody(resp)
-				retryCount = retryCount + 1
+				retryCount++
 			}
 			if err != nil {
 				return processors, err

--- a/exporter/moonshot/exporter.go
+++ b/exporter/moonshot/exporter.go
@@ -251,7 +251,7 @@ func fetch(uri, device, metricType, host, profile string, client *retryablehttp.
 
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
-			return nil, device, metricType, fmt.Errorf("Error reading Response Body - " + err.Error())
+			return nil, device, metricType, fmt.Errorf("error reading Response Body - %v", err)
 		}
 		return body, device, metricType, nil
 	}
@@ -352,7 +352,7 @@ func (e *Exporter) exportPowerMetrics(body []byte) error {
 	var msPower = (*e.deviceMetrics)["powerMetrics"]
 	err := json.Unmarshal(body, &pm)
 	if err != nil {
-		return fmt.Errorf("Error Unmarshalling PowerMetrics - " + err.Error())
+		return fmt.Errorf("error Unmarshalling PowerMetrics - %v", err)
 	}
 
 	(*msPower)["supplyTotalConsumed"].WithLabelValues().Set(float64(pm.PowerConsumedWatts))
@@ -378,7 +378,7 @@ func (e *Exporter) exportThermalMetrics(body []byte) error {
 	var msThermal = (*e.deviceMetrics)["thermalMetrics"]
 	err := json.Unmarshal(body, &tm)
 	if err != nil {
-		return fmt.Errorf("Error Unmarshalling ThermalMetrics - " + err.Error())
+		return fmt.Errorf("error Unmarshalling ThermalMetrics - %v", err)
 	}
 
 	// Iterate through fans
@@ -415,7 +415,7 @@ func (e *Exporter) exportSwitchMetrics(body []byte) error {
 	var msSw = (*e.deviceMetrics)["swMetrics"]
 	err := json.Unmarshal(body, &sm)
 	if err != nil {
-		return fmt.Errorf("Error Unmarshalling Sw - " + err.Error())
+		return fmt.Errorf("error Unmarshalling Sw - %v", err)
 	}
 
 	if sm.Status.State == "OK" {
@@ -436,7 +436,7 @@ func (e *Exporter) exportSwitchThermalMetrics(namePrefix string, body []byte) er
 	var msSwThermal = (*e.deviceMetrics)["swThermalMetrics"]
 	err := json.Unmarshal(body, &tm)
 	if err != nil {
-		return fmt.Errorf("Error Unmarshalling ThermalMetrics - " + err.Error())
+		return fmt.Errorf("error Unmarshalling ThermalMetrics - %v", err)
 	}
 
 	// Iterate through sensors
@@ -461,7 +461,7 @@ func (e *Exporter) exportSwitchPowerMetrics(namePrefix string, body []byte) erro
 	var msSwPower = (*e.deviceMetrics)["swPowerMetrics"]
 	err := json.Unmarshal(body, &spm)
 	if err != nil {
-		return fmt.Errorf("Error Unmarshalling SwPowerMetrics - " + err.Error())
+		return fmt.Errorf("error Unmarshalling SwPowerMetrics - %v", err)
 	}
 
 	(*msSwPower)["moonshotSwitchSupplyOutput"].WithLabelValues(namePrefix + "-" + spm.Name).Set(float64(spm.Oem.Hp.InstantWattage))

--- a/exporter/moonshot/exporter.go
+++ b/exporter/moonshot/exporter.go
@@ -267,7 +267,7 @@ func (e *Exporter) scrape() {
 	scrapes := len(e.pool.Tasks)
 	scrapeChan := make(chan uint8, scrapes)
 
-	// Concurrently call the endpoints to help prevent reaching the maxiumum number of 4 simultaneous sessions
+	// Concurrently call the endpoints to help prevent reaching the maximum number of 4 simultaneous sessions
 	e.pool.Run()
 	for _, task := range e.pool.Tasks {
 		var err error

--- a/helm/fishymetrics/README.md
+++ b/helm/fishymetrics/README.md
@@ -49,7 +49,7 @@ The following table lists the configurable parameters of the fishymetrics chart 
 | `vault.roleId`                                              | vault Role ID for AppRole                                                                  | `""`                      |
 | `vault.secretId`                                            | vault Secret ID for AppRole                                                                | `""`                      |
 | `vault.kv2MountPath`                                        | vault config path where kv2 secrets are mounted                                            | `"kv2"`                   |
-| `vault.kv2Path`                                             | vault path where kv2 secrets will be retreived                                             | `"path/to/secret"`        |
+| `vault.kv2Path`                                             | vault path where kv2 secrets will be retrieved                                             | `"path/to/secret"`        |
 | `vault.kv2UserField`                                        | vault kv2 secret field where we get the username                                           | `"user"`                  |
 | `vault.kv2PasswordField`                                    | vault kv2 secret field where we get the password                                           | `"password"`              |
 | `collector.drives.modulesExclude`                           | drive module(s) to exclude from the scrape                                                 | `""`                      |

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -29,13 +29,8 @@ import (
 
 var (
 	logger      *zap.Logger
-	path        string
 	atomicLevel zap.AtomicLevel
 )
-
-type lumberjackSink struct {
-	*lumberjack.Logger
-}
 
 type LoggerConfig struct {
 	LogLevel       string
@@ -49,10 +44,6 @@ type LogFile struct {
 	MaxSize    int
 	MaxBackups int
 	MaxAge     int
-}
-
-func (lumberjackSink) Sync() error {
-	return nil
 }
 
 func Initialize(svc, hostname string, config LoggerConfig) error {
@@ -178,10 +169,6 @@ func ProdEncoderConf() zapcore.EncoderConfig {
 }
 
 func Verbosity(w http.ResponseWriter, r *http.Request) {
-	type Results struct {
-		Level string `json:"verbosity"`
-	}
-
 	log := zap.L()
 	level := GetLevel()
 	log.Info("current logging level", zap.String("level", level))

--- a/middleware/logging/logging.go
+++ b/middleware/logging/logging.go
@@ -32,6 +32,9 @@ var (
 	)
 )
 
+// TraceIDKey is used to store traceID values to the HTTP request context
+type TraceIDKey string
+
 // LoggingHandler accepts an http.Handler and wraps it with a
 // handler that logs the request and response information.
 func LoggingHandler(h http.Handler) http.Handler {
@@ -42,8 +45,7 @@ func LoggingHandler(h http.Handler) http.Handler {
 	log = zap.L()
 
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		newCtx := context.WithValue(req.Context(), "traceID", generate())
-		req = req.WithContext(newCtx)
+		req = req.WithContext(context.WithValue(req.Context(), TraceIDKey("traceID"), generate()))
 		srw := statusResponseWriter{ResponseWriter: w, status: http.StatusOK}
 		query := req.URL.Query()
 

--- a/middleware/muxprom/middleware.go
+++ b/middleware/muxprom/middleware.go
@@ -58,7 +58,7 @@ func NewDefaultInstrumentation() *Instrumentation {
 	return &i
 }
 
-// Middleware satisifies the mux middleware interface
+// Middleware satisfies the mux middleware interface
 func (i *Instrumentation) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		startTime := time.Now()

--- a/middleware/muxprom/middleware.go
+++ b/middleware/muxprom/middleware.go
@@ -77,7 +77,7 @@ func (i *Instrumentation) Middleware(next http.Handler) http.Handler {
 		i.reqSizeBytes.WithLabelValues(defaultLabelVals...).Observe(float64(estimateRequestSize(r)))
 		i.reqTotal.WithLabelValues(defaultLabelVals...).Inc()
 		i.resSizeBytes.WithLabelValues(defaultLabelVals...).Observe(float64(sResponseWriter.size))
-		i.reqDurationSecs.WithLabelValues(defaultLabelVals...).Observe(time.Now().Sub(startTime).Seconds())
+		i.reqDurationSecs.WithLabelValues(defaultLabelVals...).Observe(time.Since(startTime).Seconds())
 	})
 }
 

--- a/plugins/nuova/handlers.go
+++ b/plugins/nuova/handlers.go
@@ -30,7 +30,7 @@ func (n *NuovaPlugin) exportXMLDriveMetrics(body []byte) error {
 	var drv = (*n.DeviceMetrics)["diskDriveMetrics"]
 	err := xml.Unmarshal(body, &dm)
 	if err != nil {
-		return fmt.Errorf("Error Unmarshalling XMLDriveMetrics - " + err.Error())
+		return fmt.Errorf("error Unmarshalling XMLDriveMetrics - %v", err)
 	}
 
 	for _, drive := range dm.OutConfigs.Drives {

--- a/plugins/nuova/helpers.go
+++ b/plugins/nuova/helpers.go
@@ -103,7 +103,7 @@ func checkRaidController(url, host string, client *retryablehttp.Client) (bool, 
 
 	_, err = io.ReadAll(resp.Body)
 	if err != nil {
-		return true, fmt.Errorf("Error reading Response Body - " + err.Error())
+		return true, fmt.Errorf("error reading Response Body - %s", err)
 	}
 
 	return true, nil
@@ -138,7 +138,7 @@ func IMCPost(uri, classId, cookie string, client *retryablehttp.Client) ([]byte,
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("Error reading Response Body - " + err.Error())
+		return nil, fmt.Errorf("error reading Response Body - %v", err)
 	}
 
 	return body, nil
@@ -156,12 +156,12 @@ func IMCLogin(uri, target string, client *retryablehttp.Client) (string, error) 
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return aaaLogin.OutCookie, fmt.Errorf("Error reading Response Body - " + err.Error())
+		return aaaLogin.OutCookie, fmt.Errorf("error reading Response Body - %v", err)
 	}
 
 	err = xml.Unmarshal(body, &aaaLogin)
 	if err != nil {
-		return aaaLogin.OutCookie, fmt.Errorf("error unmarshalling UCS chassis aaaLogin struct - " + err.Error())
+		return aaaLogin.OutCookie, fmt.Errorf("error unmarshalling UCS chassis aaaLogin struct - %v", err)
 	}
 
 	if aaaLogin.ErrorCode != "" {

--- a/plugins/nuova/helpers.go
+++ b/plugins/nuova/helpers.go
@@ -70,12 +70,12 @@ type AaaLogoutPayload struct {
 }
 
 func checkRaidController(url, host string, client *retryablehttp.Client) (bool, error) {
-	var resp *http.Response
-	var err error
 	retryCount := 0
-	req := common.BuildRequest(url, host)
-
-	resp, err = common.DoRequest(client, req)
+	req, err := common.BuildRequest(url, host)
+	if err != nil {
+		return false, nil
+	}
+	resp, err := common.DoRequest(client, req)
 	if err != nil {
 		return false, nil
 	}
@@ -89,7 +89,7 @@ func checkRaidController(url, host string, client *retryablehttp.Client) (bool, 
 					return false, nil
 				}
 				defer common.EmptyAndCloseBody(resp)
-				retryCount = retryCount + 1
+				retryCount++
 			}
 			if err != nil {
 				return false, nil


### PR DESCRIPTION
hello Comcasters!

I took a look at this project and noticed that there is currently no linting or spell checking in the CI tests. I didn't add these automations in this PR, but did do the following:
*  locally ran `golanci-lint run` and fixed all of the linter issues, save for a few where an `error` return value is not checked.
  * remove unused variables
  * ensure `fmt.Errorf()` always includes proper formatting tokens
  * use `++` to increment by a value of 1
  * use `:=` to instantiate variables when possible instead of unnecessary `var`s
* ran `codespell | grep -v vendor` and fixed all of the identified spelling typos.
* added an `error` return value onto `common.BuildRequest` and enabled the error check on `retryablehttp.NewRequest`, which fixes the panic reported in #118 . All calls to `common.BuildRequest` updated to handle the new error case.

Observation: I noticed that the nuova plugin's `checkRaidController` returns `false, nil` instead of `false, err` whenever an error is encountered. I left these as-is in case this is the expected behavior of the checker, but it wanted to call this out in case the error should be returned.