### PR TITLE
Add disk predictivefailure info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ log is based on the [Keep a CHANGELOG](http://keepachangelog.com/) project.
 
 ## Unreleased
 
+## Updated
+
+- Include predictive failure label to physical disk metrics [#137](https://github.com/Comcast/fishymetrics/issues/137)
+
 ## [0.15.0]
 
 ## Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ log is based on the [Keep a CHANGELOG](http://keepachangelog.com/) project.
 
 ## Updated
 
-- Include predictive failure label to physical disk metrics [#137](https://github.com/Comcast/fishymetrics/issues/137)
+- Include predictive failure label to SATA and NVMe disk metrics [#137](https://github.com/Comcast/fishymetrics/issues/137)
 
 ## [0.15.0]
 

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -58,7 +58,7 @@ const (
 	GoodNvmeDriveExpected = `
         # HELP redfish_nvme_drive_status Current NVME status 1 = OK, 0 = BAD, -1 = DISABLED
         # TYPE redfish_nvme_drive_status gauge
-        redfish_nvme_drive_status{chassisModel="model a",chassisSerialNumber="SN98765",id="DA000000",protocol="NVMe",serviceLabel="Box 3:Bay 7"} 1
+        redfish_nvme_drive_status{capacityMiB="1526185",chassisModel="model a",chassisSerialNumber="SN98765",failurePredicted="false",id="DA000000",protocol="NVMe",serialnumber="ABC123",serviceLabel="Box 3:Bay 7"} 1
 	`
 	GoodStorageControllerExpected = `
         # HELP redfish_storage_controller_status Current storage controller status 1 = OK, 0 = BAD
@@ -506,7 +506,8 @@ func Test_Exporter_Metrics_Handling(t *testing.T) {
   			    "ServiceLabel": "Box 3:Bay 7"
   			  }
   			},
-  			"Protocol": "NVMe"
+				"Protocol": "NVMe",
+				"SerialNumber": "ABC123"
 		}`)
 	var GoodStorageControllerResponse = []byte(`{
   			"Name": "SBMezz1",

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -53,7 +53,7 @@ const (
 	GoodDiskDriveExpected = `
         # HELP redfish_disk_drive_status Current Disk Drive status 1 = OK, 0 = BAD, -1 = DISABLED
         # TYPE redfish_disk_drive_status gauge
-        redfish_disk_drive_status{capacityMiB="915715",chassisModel="model a",chassisSerialNumber="SN98765",id="0",location="1I:1:1",name="HpeSmartStorageDiskDrive",serialnumber="ABC123"} 1
+        redfish_disk_drive_status{capacityMiB="915715",chassisModel="model a",chassisSerialNumber="SN98765",failurePredicted="",id="0",location="1I:1:1",name="HpeSmartStorageDiskDrive",serialnumber="ABC123"} 1
 	`
 	GoodNvmeDriveExpected = `
         # HELP redfish_nvme_drive_status Current NVME status 1 = OK, 0 = BAD, -1 = DISABLED

--- a/exporter/handlers.go
+++ b/exporter/handlers.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Comcast Cable Communications Management, LLC
+ * Copyright 2025 Comcast Cable Communications Management, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporter/handlers.go
+++ b/exporter/handlers.go
@@ -274,7 +274,7 @@ func (e *Exporter) exportPhysicalDriveMetrics(body []byte) error {
 	var dlphysical oem.DiskDriveMetrics
 	var dlphysicaldrive = (*e.DeviceMetrics)["diskDriveMetrics"]
 	var loc string
-	var diskpredictfail string
+	var failpredict string
 	var cap int
 	err := json.Unmarshal(body, &dlphysical)
 	if err != nil {
@@ -311,17 +311,17 @@ func (e *Exporter) exportPhysicalDriveMetrics(body []byte) error {
 	// if FailurePredicted is present in response, set the result, else set to empty string
 	if dlphysical.FailurePredicted != nil {
 		if *dlphysical.FailurePredicted {
-			diskpredictfail = "true"
+			failpredict = "true"
 		} else {
-			diskpredictfail = "false"
+			failpredict = "false"
 		}
 	} else {
-		diskpredictfail = ""
+		failpredict = ""
 	}
 
 	// Physical drives need to have a unique identifier like location so as to not overwrite data
 	// physical drives can have the same ID, but belong to a different ArrayController, therefore need more than just the ID as a unique identifier.
-	(*dlphysicaldrive)["driveStatus"].WithLabelValues(dlphysical.Name, e.ChassisSerialNumber, e.Model, dlphysical.Id, loc, strings.TrimRight(dlphysical.SerialNumber, " "), strconv.Itoa(cap), diskpredictfail).Set(state)
+	(*dlphysicaldrive)["driveStatus"].WithLabelValues(dlphysical.Name, e.ChassisSerialNumber, e.Model, dlphysical.Id, loc, strings.TrimRight(dlphysical.SerialNumber, " "), strconv.Itoa(cap), failpredict).Set(state)
 	return nil
 }
 
@@ -366,6 +366,8 @@ func (e *Exporter) exportLogicalDriveMetrics(body []byte) error {
 // exportNVMeDriveMetrics collects the NVME drive metrics in json format and sets the prometheus gauges
 func (e *Exporter) exportNVMeDriveMetrics(body []byte) error {
 	var state float64
+	var cap int
+	var failpredict string
 	var dlnvme oem.NVMeDriveMetrics
 	var dlnvmedrive = (*e.DeviceMetrics)["nvmeMetrics"]
 	err := json.Unmarshal(body, &dlnvme)
@@ -384,7 +386,23 @@ func (e *Exporter) exportNVMeDriveMetrics(body []byte) error {
 		state = DISABLED
 	}
 
-	(*dlnvmedrive)["nvmeDriveStatus"].WithLabelValues(e.ChassisSerialNumber, e.Model, dlnvme.Protocol, dlnvme.ID, dlnvme.PhysicalLocation.PartLocation.ServiceLabel).Set(state)
+	if dlnvme.CapacityBytes != 0 {
+		// convert to MiB
+		cap = ((dlnvme.CapacityBytes / 1024) / 1024)
+	}
+
+	// if FailurePredicted is present in response, set the result, else set to empty string
+	if dlnvme.FailurePredicted != nil {
+		if *dlnvme.FailurePredicted {
+			failpredict = "true"
+		} else {
+			failpredict = "false"
+		}
+	} else {
+		failpredict = ""
+	}
+
+	(*dlnvmedrive)["nvmeDriveStatus"].WithLabelValues(e.ChassisSerialNumber, e.Model, dlnvme.Protocol, dlnvme.ID, dlnvme.PhysicalLocation.PartLocation.ServiceLabel, dlnvme.SerialNumber, strconv.Itoa(cap), failpredict).Set(state)
 	return nil
 }
 

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -70,7 +70,7 @@ func NewDeviceMetrics() *map[string]*metrics {
 		// Splitting out the three different types of drives to gather metrics on each (NVMe, Disk Drive, and Logical Drive)
 		// NVMe Drive Metrics
 		NVMeDriveMetrics = &metrics{
-			"nvmeDriveStatus": newServerMetric("redfish_nvme_drive_status", "Current NVME status 1 = OK, 0 = BAD, -1 = DISABLED", nil, []string{"chassisSerialNumber", "chassisModel", "protocol", "id", "serviceLabel"}),
+			"nvmeDriveStatus": newServerMetric("redfish_nvme_drive_status", "Current NVME status 1 = OK, 0 = BAD, -1 = DISABLED", nil, []string{"chassisSerialNumber", "chassisModel", "protocol", "id", "serviceLabel", "serialnumber", "capacityMiB", "failurePredicted"}),
 		}
 
 		// Physical Storage Disk Drive Metrics

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -75,7 +75,7 @@ func NewDeviceMetrics() *map[string]*metrics {
 
 		// Physical Storage Disk Drive Metrics
 		DiskDriveMetrics = &metrics{
-			"driveStatus": newServerMetric("redfish_disk_drive_status", "Current Disk Drive status 1 = OK, 0 = BAD, -1 = DISABLED", nil, []string{"name", "chassisSerialNumber", "chassisModel", "id", "location", "serialnumber", "capacityMiB"}),
+			"driveStatus": newServerMetric("redfish_disk_drive_status", "Current Disk Drive status 1 = OK, 0 = BAD, -1 = DISABLED", nil, []string{"name", "chassisSerialNumber", "chassisModel", "id", "location", "serialnumber", "capacityMiB", "failurePredicted"}),
 		}
 
 		// Logical Disk Drive Metrics

--- a/oem/drive.go
+++ b/oem/drive.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Comcast Cable Communications Management, LLC
+ * Copyright 2025 Comcast Cable Communications Management, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/oem/drive.go
+++ b/oem/drive.go
@@ -83,6 +83,7 @@ type DiskDriveMetrics struct {
 	Status           Status           `json:"Status"`
 	LocationWrap     LocationWrapper  `json:"Location"`
 	PhysicalLocation PhysicalLocation `json:"PhysicalLocation"`
+	FailurePredicted *bool            `json:"FailurePredicted"`
 	SerialNumber     string           `json:"SerialNumber"`
 }
 

--- a/oem/drive.go
+++ b/oem/drive.go
@@ -37,8 +37,9 @@ type NVMeDriveMetrics struct {
 	PhysicalLocation PhysicalLocation `json:"PhysicalLocation"`
 	Protocol         string           `json:"Protocol"`
 	Status           Status           `json:"Status"`
-	FailurePredicted bool             `json:"FailurePredicted"`
+	FailurePredicted *bool            `json:"FailurePredicted"`
 	CapacityBytes    int              `json:"CapacityBytes"`
+	SerialNumber     string           `json:"SerialNumber"`
 }
 
 // Logical Drives

--- a/plugins/nuova/handlers.go
+++ b/plugins/nuova/handlers.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Comcast Cable Communications Management, LLC
+ * Copyright 2025 Comcast Cable Communications Management, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/nuova/handlers.go
+++ b/plugins/nuova/handlers.go
@@ -40,7 +40,7 @@ func (n *NuovaPlugin) exportXMLDriveMetrics(body []byte) error {
 			} else {
 				state = BAD
 			}
-			(*drv)["driveStatus"].WithLabelValues(drive.Name, n.ChassisSerialNumber, n.Model, drive.Id, "", "", "").Set(state)
+			(*drv)["driveStatus"].WithLabelValues(drive.Name, n.ChassisSerialNumber, n.Model, drive.Id, "", "", "", "").Set(state)
 		}
 	}
 


### PR DESCRIPTION
Include "failurePredicted" in disk metrics.

If FailurePredicted available in response: (true/false)
```
# HELP redfish_disk_drive_status Current Disk Drive status 1 = OK, 0 = BAD, -1 = DISABLED
# TYPE redfish_disk_drive_status gauge
redfish_disk_drive_status{capacityMiB="1526185",chassisModel="r660",chassisSerialNumber="xxxxxx",failurePredicted="false",id="Disk.Bay.0:Enclosure.Internal.0-1",location="",name="PCIe SSD in Slot 0 in Bay 1",serialnumber="xxxxxx"} 1
redfish_disk_drive_status{capacityMiB="1526185",chassisModel="r660",chassisSerialNumber="xxxxxx",failurePredicted="false",id="Disk.Bay.1:Enclosure.Internal.0-1",location="",name="PCIe SSD in Slot 1 in Bay 1",serialnumber="xxxxxx"} 1
```

If FailurePredicted not available in response: (empty string)
```
# HELP redfish_disk_drive_status Current Disk Drive status 1 = OK, 0 = BAD, -1 = DISABLED
# TYPE redfish_disk_drive_status gauge
redfish_disk_drive_status{capacityMiB="915715",chassisModel="synergy480",chassisSerialNumber="xxxxxx",failurePredicted="",id="0",location="1I:1:1",name="HpeSmartStorageDiskDrive",serialnumber="xxxxxx"} 1
redfish_disk_drive_status{capacityMiB="915715",chassisModel="synergy480",chassisSerialNumber="xxxxxx",failurePredicted="",id="2",location="1I:1:2",name="HpeSmartStorageDiskDrive",serialnumber="xxxxxx"} 1
```

