### PR TITLE
power: fix PSU index for everything other than HPE

### DIFF
--- a/oem/power.go
+++ b/oem/power.go
@@ -80,7 +80,7 @@ type PowerSupply struct {
 	LineInputVoltageType string       `json:"LineInputVoltageType,omitempty"`
 	InputRanges          []InputRange `json:"InputRanges,omitempty"`
 	Manufacturer         string       `json:"Manufacturer"`
-	MemberID             interface{}  `json:"MemberId"`
+	MemberID             string       `json:"MemberId"`
 	Model                string       `json:"Model"`
 	Name                 string       `json:"Name"`
 	Oem                  OemPower     `json:"Oem,omitempty"`


### PR DESCRIPTION
It should not properly interpret the PSU index for everything Redfish compliant besides HPE.
Beware: the ID of the PSUs may change and be indexed from 0 if you have a recent enough iLO version (probably anything iLO 5+, needs check).