### PR TITLE
Add static binary build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,15 @@ build:
 		-X \"github.com/comcast/fishymetrics/buildinfo.date=${BUILD_DATE}\"\
 	" -v -o build/usr/bin/fishymetrics $(shell pwd)/cmd/fishymetrics
 
+static:
+    @mkdir -p build/usr/bin
+    CGO_ENABLED=0 go build -a -ldflags "\
+        -extldflags '-static' \
+        -X \"github.com/comcast/fishymetrics/buildinfo.gitVersion=${REPO_VERSION}\" \
+        -X \"github.com/comcast/fishymetrics/buildinfo.gitRevision=${REPO_REV}\" \
+        -X \"github.com/comcast/fishymetrics/buildinfo.date=${BUILD_DATE}\" \
+    " -v -o build/usr/bin/fishymetrics $(shell pwd)/cmd/fishymetrics
+
 docker:
 	docker build \
 	--platform linux/amd64 \

--- a/README.md
+++ b/README.md
@@ -255,6 +255,12 @@ The chart maps these values to the container env vars. The application’s HTTP 
 make build
 ```
 
+#### linux binary statically linked
+
+```
+make static
+```
+
 #### docker image
 
 ```bash


### PR DESCRIPTION
Currently the Linux binary is build dynamically and not very portable.

The end resulting binary would be more very useful to have a statically built binary to be portable. (potentially a binary download artifact on the repo)