### PR TITLE
vault: add KV v2 support for custom mount paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,21 @@ Flags:
                                         path: "path/to/secret"
                                         userField: "user"
                                         passwordField: "password"
+                                        kvVersion: 2
                                       ...
                                   "
 
-                                --credentials.profiles='{"profiles":[{"name":"profile1","mountPath":"kv2","path":"path/to/secret","userField":"user","passwordField":"password"},...]}'
+                                --credentials.profiles='{"profiles":[{"name":"profile1","mountPath":"kv2","path":"path/to/secret","userField":"user","passwordField":"password","kvVersion":2},...]}'
+
+                                Profile Fields:
+                                  - name: Profile identifier (required)
+                                  - mountPath: Vault mount path (required)
+                                  - path: Path to secret within mount (required)
+                                  - userField: Field name for username in secret (required for KV secrets without userName)
+                                  - passwordField: Field name for password in secret (required)
+                                  - kvVersion: Vault KV engine version - 1 or 2 (optional, default: 1)
+                                  - secretName: Use a fixed secret name instead of target hostname (optional)
+                                  - userName: Use a fixed username instead of reading from secret (optional)
 ```
 
 Or set the following ENV Variables:

--- a/common/credentials.go
+++ b/common/credentials.go
@@ -59,6 +59,7 @@ type ProfileFlag struct {
 	PasswordField string `json:"passwordField" yaml:"passwordField"`
 	SecretName    string `json:"secretName,omitempty" yaml:"secretName,omitempty"`
 	UserName      string `json:"userName,omitempty" yaml:"userName,omitempty"`
+	KVVersion     int    `json:"kvVersion,omitempty" yaml:"kvVersion,omitempty"`
 }
 
 type CredProfileFunc func(*fishy_vault.SecretProperties)
@@ -127,6 +128,7 @@ func (c *ChassisCredentials) populateProfiles(profiles *CredentialProfilesFlag) 
 			PasswordField: v.PasswordField,
 			SecretName:    v.SecretName,
 			UserName:      v.UserName,
+			KVVersion:     v.KVVersion,
 		}
 	}
 }

--- a/docs/url-extra-params.md
+++ b/docs/url-extra-params.md
@@ -58,6 +58,7 @@ profiles:
     path: "bmc/{environment}/credentials"
     userField: "username"
     passwordField: "password"
+    kvVersion: 2
 ```
 
 The `{environment}` placeholder will be replaced with `production`, resulting in the Vault path:
@@ -87,6 +88,7 @@ profiles:
     path: "customers/{customer}/dc/{datacenter}/bmc"
     userField: "user"
     passwordField: "pass"
+    kvVersion: 2
 ```
 
 Results in Vault path:
@@ -186,6 +188,7 @@ credentials:
       path: "bmc/{environment}/{rack}/credentials"
       userField: "username"
       passwordField: "password"
+      kvVersion: 2
 ```
 
 ### JSON Configuration
@@ -198,8 +201,24 @@ credentials:
       "mountPath": "kv2",
       "path": "bmc/{environment}/{rack}/credentials",
       "userField": "username",
-      "passwordField": "password"
+      "passwordField": "password",
+      "kvVersion": 2
     }
   ]
 }
 ```
+
+### Profile Field Reference
+
+- **name** (required): Unique identifier for the profile
+- **mountPath** (required): Vault mount point for the secrets engine
+- **path** (required): Path to the secret within the mount (supports placeholders)
+- **userField** (required*): Field name containing the username in the secret
+- **passwordField** (required): Field name containing the password in the secret
+- **kvVersion** (optional): Vault KV secrets engine version - `1` or `2` (default: `1`)
+- **secretName** (optional): Use a fixed secret name instead of the target hostname
+- **userName** (optional): Use a fixed username instead of reading from the secret
+
+\* Required unless `userName` is specified
+
+**Note**: When using Vault KV version 2, ensure `kvVersion: 2` is set in your profile. KV v2 automatically handles the `/data/` path segment in the API request. If not specified, the default is KV v1.

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -50,6 +50,7 @@ type SecretProperties struct {
 	PasswordField string
 	SecretName    string
 	UserName      string
+	KVVersion     int
 }
 
 type Vault struct {
@@ -115,7 +116,9 @@ func (v *Vault) login(ctx context.Context) (*vault.Secret, error) {
 	return authInfo, nil
 }
 
-// GetKVSecret fetches the latest version of secret api key from kv-v1 or kv-v2
+// GetKVSecret retrieves a secret from Vault using KV v1 or KV v2.
+// MountPath is the actual Vault mount (e.g., "testing-path"),
+// while KVVersion controls which API (v1/v2) is used.
 func (v *Vault) GetKVSecret(ctx context.Context, props *SecretProperties, secret string) (*vault.KVSecret, error) {
 	var kvSecret *vault.KVSecret
 	var err error
@@ -134,12 +137,11 @@ func (v *Vault) GetKVSecret(ctx context.Context, props *SecretProperties, secret
 			secretPath = secret
 		}
 	}
-
-	// perform more checks based on profile
-	if props.MountPath != "kv2" {
-		kvSecret, err = v.client.KVv1(props.MountPath).Get(ctx, secretPath)
-	} else {
+	switch props.KVVersion {
+	case 2:
 		kvSecret, err = v.client.KVv2(props.MountPath).Get(ctx, secretPath)
+	default:
+		kvSecret, err = v.client.KVv1(props.MountPath).Get(ctx, secretPath)
 	}
 
 	if err != nil {

--- a/vault/vault_test.go
+++ b/vault/vault_test.go
@@ -61,6 +61,16 @@ func createVaultTestCluster(t *testing.T) (*docker.DockerCluster, string, string
 		t.Fatal(err)
 	}
 
+	// create KV V2 mount with a custom mount name
+	if err := client.Sys().Mount("custom-kv2", &vaultapi.MountInput{
+		Type: "kv",
+		Options: map[string]string{
+			"version": "2",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
 	// enable approle
 	if err := client.Sys().EnableAuthWithOptions("approle", &vaultapi.EnableAuthOptions{
 		Type: "approle",
@@ -117,6 +127,15 @@ func createVaultTestCluster(t *testing.T) (*docker.DockerCluster, string, string
 	}
 
 	if _, err := client.Logical().Write("kv2/data/morepath/testkv2secret", map[string]interface{}{
+		"data": map[string]interface{}{
+			"value": "testkv2value",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create KV2 secret under custom mount
+	if _, err := client.Logical().Write("custom-kv2/data/ipmi/testkv2secret", map[string]interface{}{
 		"data": map[string]interface{}{
 			"value": "testkv2value",
 		},
@@ -274,6 +293,7 @@ func Test_Vault_Auth(t *testing.T) {
 			loginFunc:         login,
 			secretProps: &SecretProperties{
 				MountPath:  "kv2",
+				KVVersion:  2,
 				SecretName: "missing",
 			},
 			getSecretFunc: getSecret,
@@ -289,6 +309,7 @@ func Test_Vault_Auth(t *testing.T) {
 			secretProps: &SecretProperties{
 				MountPath:  "kv2",
 				Path:       "morepath",
+				KVVersion:  2,
 				SecretName: "testkv2secret",
 			},
 			getSecretFunc: getSecret,
@@ -303,6 +324,7 @@ func Test_Vault_Auth(t *testing.T) {
 			loginFunc:         login,
 			secretProps: &SecretProperties{
 				MountPath: "kv2",
+				KVVersion: 2,
 				Path:      "morepath",
 			},
 			getSecretFunc: getSecret,
@@ -317,6 +339,7 @@ func Test_Vault_Auth(t *testing.T) {
 			loginFunc:         login,
 			secretProps: &SecretProperties{
 				MountPath:  "kv2",
+				KVVersion:  2,
 				SecretName: "testkv2secret",
 			},
 			getSecretFunc: getSecret,
@@ -331,6 +354,7 @@ func Test_Vault_Auth(t *testing.T) {
 			loginFunc:         login,
 			secretProps: &SecretProperties{
 				MountPath: "kv2",
+				KVVersion: 2,
 			},
 			getSecretFunc: getSecret,
 			cleanUpFunc:   cleanUp,
@@ -351,12 +375,29 @@ func Test_Vault_Auth(t *testing.T) {
 			expectErr:     false,
 		},
 		{
+			name:              "Get KVv2 Secret Custom Mount",
+			ctx:               ctx,
+			vaultParams:       goodParams,
+			appRoleClientFunc: createAppRoleClient,
+			loginFunc:         login,
+			secretProps: &SecretProperties{
+				MountPath:  "custom-kv2",
+				Path:       "ipmi",
+				KVVersion:  2,
+				SecretName: "testkv2secret",
+			},
+			getSecretFunc: getSecret,
+			cleanUpFunc:   cleanUp,
+			expectErr:     false,
+		},
+		{
 			name:              "Token Renewal",
 			ctx:               ctx,
 			vaultParams:       goodParams,
 			appRoleClientFunc: createAppRoleClient,
 			secretProps: &SecretProperties{
 				MountPath: "kv2",
+				KVVersion: 2,
 			},
 			validateFunc: func(t *testing.T, tc testcase) error {
 				var wg = sync.WaitGroup{}
@@ -388,6 +429,7 @@ func Test_Vault_Auth(t *testing.T) {
 			appRoleClientFunc: createAppRoleClient,
 			secretProps: &SecretProperties{
 				MountPath: "kv2",
+				KVVersion: 2,
 			},
 			validateFunc: func(t *testing.T, tc testcase) error {
 				var wg = sync.WaitGroup{}


### PR DESCRIPTION
vault: fix KV v2 handling by separating mountPath from KV version

Previously KV v2 was only used when mountPath == "kv2".
This change introduces KVVersion to correctly support KV v2
engines mounted under arbitrary paths, and updates tests accordingly.