### PR TITLE
Allow consuming existing secret

### DIFF
--- a/helm/fishymetrics/templates/secret.yaml
+++ b/helm/fishymetrics/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not $.Values.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,3 +13,4 @@ data:
   vault-secret-id: {{ .Values.vault.secretId | b64enc | quote }}
   elastic-user: {{ .Values.vector.elasticsearch.user | b64enc | quote }}
   elastic-pass: {{ .Values.vector.elasticsearch.pass | b64enc | quote }}
+{{- end -}}

--- a/helm/fishymetrics/values.yaml
+++ b/helm/fishymetrics/values.yaml
@@ -16,6 +16,10 @@ log:
   fileMaxBackups: "1"
   fileMaxAge: "1"
 
+# Set to true to consume an existing secret. 
+# For backwards compatibility, the secret name is still expected to be {{ template "fishymetrics.name" . }}-creds
+existingSecret: false
+
 bmc:
   username: ""
   password: ""


### PR DESCRIPTION
This MR uses a new boolean key named existingSecret in the values file to toggle the creation of the secret holding the BMC, vault and elastic credentials. This is important for setups were deployments are controlled via GitOps were storing confidential keys in plain text is considered a security risk.
The default value has been set to false to ensure backwards compatibility, for the same reason the secret name is still expected to be the same as before. Setting the value to true will result in Helm not templating the secret, the expectation being the user has created before hand.