### PR TITLE
Include thermal sensor upper critical threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ log is based on the [Keep a CHANGELOG](http://keepachangelog.com/) project.
 
 ## Added
 
-- Capture critical threshold in temperature reading [#176](https://github.com/Comcast/fishymetrics/issues/176)
+- Capture critical threshold in sensor temperature [#176](https://github.com/Comcast/fishymetrics/issues/176)
 
 
 ## [0.19.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ log is based on the [Keep a CHANGELOG](http://keepachangelog.com/) project.
 
 ## Unreleased
 
+## Added
+
+- Capture critical threshold in temperature reading [#176](https://github.com/Comcast/fishymetrics/issues/176)
+
+
 ## [0.19.0]
 
 ## Added

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -117,7 +117,7 @@ const (
 	`
 	GoodThermalSensorThresholdCriticalExpected = `
         # HELP redfish_thermal_sensor_threshold_critical Current sensor upper threshold critical reading in Celsius
-				# TYPE redfish_thermal_sensor_threshold_critical gauge
+        # TYPE redfish_thermal_sensor_threshold_critical gauge
         redfish_thermal_sensor_threshold_critical{chassisModel="model a",chassisSerialNumber="SN98765",name="01-Inlet Ambient"} 42
 	`
 	GoodPowerVoltageOutputExpected = `

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -115,6 +115,11 @@ const (
         # TYPE redfish_thermal_sensor_temperature gauge
         redfish_thermal_sensor_temperature{chassisModel="model a",chassisSerialNumber="SN98765",name="01-Inlet Ambient"} 22
 	`
+	GoodThermalSensorThresholdCriticalExpected = `
+        # HELP redfish_thermal_sensor_threshold_critical Current sensor upper threshold critical reading in Celsius
+				# TYPE redfish_thermal_sensor_threshold_critical gauge
+        redfish_thermal_sensor_threshold_critical{chassisModel="model a",chassisSerialNumber="SN98765",name="01-Inlet Ambient"} 42
+	`
 	GoodPowerVoltageOutputExpected = `
         # HELP redfish_power_voltage_output Power voltage output in volts
         # TYPE redfish_power_voltage_output gauge
@@ -1366,6 +1371,15 @@ func Test_Exporter_Metrics_Handling(t *testing.T) {
 			handleFunc: thermMetrics,
 			response:   GoodThermalSensorTempResponse,
 			expected:   GoodThermalSensorTempExpected,
+		},
+		{
+			name:       "Good Thermal Sensor Threshold Critical",
+			metricName: "redfish_thermal_sensor_threshold_critical",
+			metricRef1: "thermalMetrics",
+			metricRef2: "sensorThresholdCritical",
+			handleFunc: thermMetrics,
+			response:   GoodThermalSensorTempResponse,
+			expected:   GoodThermalSensorThresholdCriticalExpected,
 		},
 		{
 			name:       "Good Power Voltage Output",

--- a/exporter/handlers.go
+++ b/exporter/handlers.go
@@ -299,6 +299,21 @@ func (e *Exporter) exportThermalMetrics(body []byte) error {
 				celsTemp = sensor.ReadingCelsius.(float64)
 			}
 			(*therm)["sensorTemperature"].WithLabelValues(strings.TrimRight(sensor.Name, " "), e.ChassisSerialNumber, e.Model).Set(celsTemp)
+
+			// Handle UpperThresholdCritical - it can be null, int, or float64
+			if sensor.UpperThresholdCritical != nil {
+				var thresholdCritical float64
+				switch sensor.UpperThresholdCritical.(type) {
+				case string:
+					thresholdCritical, _ = strconv.ParseFloat(sensor.UpperThresholdCritical.(string), 32)
+				case int:
+					thresholdCritical = float64(sensor.UpperThresholdCritical.(int))
+				case float64:
+					thresholdCritical = sensor.UpperThresholdCritical.(float64)
+				}
+				(*therm)["sensorThresholdCritical"].WithLabelValues(strings.TrimRight(sensor.Name, " "), e.ChassisSerialNumber, e.Model).Set(thresholdCritical)
+			}
+
 			if sensor.Status.Health == "OK" {
 				state = OK
 			} else {

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -40,11 +40,12 @@ func NewDeviceMetrics() *map[string]*metrics {
 		}
 
 		ThermalMetrics = &metrics{
-			"fanSpeed":          newServerMetric("redfish_thermal_fan_speed", "Current fan speed in the unit of percentage, possible values are 0 - 100", nil, []string{"name", "chassisSerialNumber", "chassisModel"}),
-			"fanStatus":         newServerMetric("redfish_thermal_fan_status", "Current fan status 1 = OK, 0 = BAD", nil, []string{"name", "chassisSerialNumber", "chassisModel"}),
-			"sensorTemperature": newServerMetric("redfish_thermal_sensor_temperature", "Current sensor temperature reading in Celsius", nil, []string{"name", "chassisSerialNumber", "chassisModel"}),
-			"sensorStatus":      newServerMetric("redfish_thermal_sensor_status", "Current sensor status 1 = OK, 0 = BAD", nil, []string{"name", "chassisSerialNumber", "chassisModel"}),
-			"thermalSummary":    newServerMetric("redfish_thermal_summary_status", "Current sensor status 1 = OK, 0 = BAD", nil, []string{"url", "chassisSerialNumber", "chassisModel"}),
+			"fanSpeed":                newServerMetric("redfish_thermal_fan_speed", "Current fan speed in the unit of percentage, possible values are 0 - 100", nil, []string{"name", "chassisSerialNumber", "chassisModel"}),
+			"fanStatus":               newServerMetric("redfish_thermal_fan_status", "Current fan status 1 = OK, 0 = BAD", nil, []string{"name", "chassisSerialNumber", "chassisModel"}),
+			"sensorTemperature":       newServerMetric("redfish_thermal_sensor_temperature", "Current sensor temperature reading in Celsius", nil, []string{"name", "chassisSerialNumber", "chassisModel"}),
+			"sensorThresholdCritical": newServerMetric("redfish_thermal_sensor_threshold_critical", "Current sensor upper threshold critical reading in Celsius", nil, []string{"name", "chassisSerialNumber", "chassisModel"}),
+			"sensorStatus":            newServerMetric("redfish_thermal_sensor_status", "Current sensor status 1 = OK, 0 = BAD", nil, []string{"name", "chassisSerialNumber", "chassisModel"}),
+			"thermalSummary":          newServerMetric("redfish_thermal_summary_status", "Current sensor status 1 = OK, 0 = BAD", nil, []string{"url", "chassisSerialNumber", "chassisModel"}),
 		}
 
 		PowerMetrics = &metrics{

--- a/oem/thermal.go
+++ b/oem/thermal.go
@@ -48,5 +48,5 @@ type Temperature struct {
 	SensorNumber           int         `json:"SensorNumber"`
 	Status                 Status      `json:"Status"`
 	UpperThresholdCritical interface{} `json:"UpperThresholdCritical"`
-	UpperThresholdFatal    int         `json:"UpperThresholdFatal"`
+	UpperThresholdFatal    interface{} `json:"UpperThresholdFatal"`
 }


### PR DESCRIPTION
**Sample of what will be added to scrape results:**
```
# HELP redfish_thermal_sensor_threshold_critical Current sensor upper threshold critical reading in Celsius
# TYPE redfish_thermal_sensor_threshold_critical gauge
redfish_thermal_sensor_threshold_critical{chassisModel="xl450g9",chassisSerialNumber="XXXXXXXXX",name="01-Inlet Ambient"} 42
redfish_thermal_sensor_threshold_critical{chassisModel="xl450g9",chassisSerialNumber="XXXXXXXXX",name="02-CPU 1"} 70
redfish_thermal_sensor_threshold_critical{chassisModel="xl450g9",chassisSerialNumber="XXXXXXXXX",name="03-CPU 2"} 70
redfish_thermal_sensor_threshold_critical{chassisModel="xl450g9",chassisSerialNumber="XXXXXXXXX",name="04-P1 DIMM 1-4"} 87
redfish_thermal_sensor_threshold_critical{chassisModel="xl450g9",chassisSerialNumber="XXXXXXXXX",name="05-P1 DIMM 5-8"} 87
redfish_thermal_sensor_threshold_critical{chassisModel="xl450g9",chassisSerialNumber="XXXXXXXXX",name="06-P2 DIMM 1-4"} 87
redfish_thermal_sensor_threshold_critical{chassisModel="xl450g9",chassisSerialNumber="XXXXXXXXX",name="07-P2 DIMM 5-8"} 87
redfish_thermal_sensor_threshold_critical{chassisModel="xl450g9",chassisSerialNumber="XXXXXXXXX",name="08-HD Max"} 60
redfish_thermal_sensor_threshold_critical{chassisModel="xl450g9",chassisSerialNumber="XXXXXXXXX",name="09-Chipset"} 105
redfish_thermal_sensor_threshold_critical{chassisModel="xl450g9",chassisSerialNumber="XXXXXXXXX",name="11-VR P1"} 115
redfish_thermal_sensor_threshold_critical{chassisModel="xl450g9",chassisSerialNumber="XXXXXXXXX",name="12-VR P2"} 115
redfish_thermal_sensor_threshold_critical{chassisModel="xl450g9",chassisSerialNumber="XXXXXXXXX",name="13-VR P1Mem"} 115
redfish_thermal_sensor_threshold_critical{chassisModel="xl450g9",chassisSerialNumber="XXXXXXXXX",name="14-VR P1Mem"} 115
redfish_thermal_sensor_threshold_critical{chassisModel="xl450g9",chassisSerialNumber="XXXXXXXXX",name="15-VR P2Mem"} 115
redfish_thermal_sensor_threshold_critical{chassisModel="xl450g9",chassisSerialNumber="XXXXXXXXX",name="16-VR P2Mem"} 115
redfish_thermal_sensor_threshold_critical{chassisModel="xl450g9",chassisSerialNumber="XXXXXXXXX",name="17-Storage Batt"} 65
redfish_thermal_sensor_threshold_critical{chassisModel="xl450g9",chassisSerialNumber="XXXXXXXXX",name="18-Battery Zone"} 65
redfish_thermal_sensor_threshold_critical{chassisModel="xl450g9",chassisSerialNumber="XXXXXXXXX",name="19-HD Controller"} 100
redfish_thermal_sensor_threshold_critical{chassisModel="xl450g9",chassisSerialNumber="XXXXXXXXX",name="21-PCI Zone"} 80
redfish_thermal_sensor_threshold_critical{chassisModel="xl450g9",chassisSerialNumber="XXXXXXXXX",name="24-PCI 3"} 100
redfish_thermal_sensor_threshold_critical{chassisModel="xl450g9",chassisSerialNumber="XXXXXXXXX",name="26-P/S 1"} 0
redfish_thermal_sensor_threshold_critical{chassisModel="xl450g9",chassisSerialNumber="XXXXXXXXX",name="27-P/S 2"} 0
redfish_thermal_sensor_threshold_critical{chassisModel="xl450g9",chassisSerialNumber="XXXXXXXXX",name="28-P/S 3"} 0
redfish_thermal_sensor_threshold_critical{chassisModel="xl450g9",chassisSerialNumber="XXXXXXXXX",name="29-P/S 4"} 0
redfish_thermal_sensor_threshold_critical{chassisModel="xl450g9",chassisSerialNumber="XXXXXXXXX",name="30-System Board"} 80
redfish_thermal_sensor_threshold_critical{chassisModel="xl450g9",chassisSerialNumber="XXXXXXXXX",name="31-Sys Exhaust"} 80
# HELP redfish_up was the last scrape of fishymetrics successful.
# TYPE redfish_up gauge
redfish_up 1
```